### PR TITLE
CMFSUPPORT-1635 : Open sourcing RdkWanManager component

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,3 @@
 # Contributing
 
-If you wish to make code contributions to this project, the master source is hosted at [code.rdkcentral.com](https://code.rdkcentral.com/r/#/admin/projects/rdkb/components/opensource/ccsp/RdkWanManager).
-You can submit your changes for review via that site.
-
-Please follow the [workflow](https://wiki.rdkcentral.com/display/CMF/Gerrit+Development+Workflow) when making a contribution.
-
-In order to contribute code, first-time users are requested to agree to the [license](https://wiki.rdkcentral.com/signup.action).
+If you would like to contribute code to this project you can do so through GitHub by forking the repository and sending a pull request. Before RDK accepts your code into the project you must sign the RDK Contributor License Agreement (CLA).

--- a/source/TR-181/netmonitor/network_route_monitor.c
+++ b/source/TR-181/netmonitor/network_route_monitor.c
@@ -1,3 +1,22 @@
+/*
+ * If not stated otherwise in this file or this component's Licenses.txt file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2024 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
 /* ---- Include Files ---------------------------------------- */
 #include <unistd.h>
 #include <linux/rtnetlink.h>

--- a/source/TR-181/netmonitor/network_route_monitor.h
+++ b/source/TR-181/netmonitor/network_route_monitor.h
@@ -1,3 +1,22 @@
+/*
+ * If not stated otherwise in this file or this component's Licenses.txt file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2024 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
 #ifndef _NETWORK_ROUTE_MONITOR_H_
 #define _NETWORK_ROUTE_MONITOR_H_
 


### PR DESCRIPTION
- CONTRIBUTING.md is not the github flavour (as per e.g. rdkservices)
- Two files are missing RDK Apache-2 headers: 
- source/TR-181/netmonitor/network_route_monitor.c
source/TR-181/netmonitor/network_route_monitor.h