### PR TITLE
RDKB-54933 : Rearranging Device.DHCPv6.Client.1.Enable parameter

### DIFF
--- a/source/TR-181/middle_layer_src/wanmgr_dml_dhcpv6.c
+++ b/source/TR-181/middle_layer_src/wanmgr_dml_dhcpv6.c
@@ -610,13 +610,13 @@ Client3_GetParamBoolValue
     if (strcmp(ParamName, "Enable") == 0)
     {
         /* collect value */
-#if defined(WAN_MANAGER_UNIFICATION_ENABLED) 
+//#if defined(WAN_MANAGER_UNIFICATION_ENABLED) 
         /* For unification enabled builds Device.DHCPv6.Client.1.Enable is not used to start the DHCP v6 client. Check if the dhcpv6 client running. */
         CcspTraceInfo(("%s %d Calling WanMgr_DmlDhcpv6cGetEnabled to get dhcpv6 status. \n", __FUNCTION__, __LINE__));
         *pBool   =WanMgr_DmlDhcpv6cGetEnabled(NULL);
-#else
+/*#else
         *pBool   = pDhcpc->Cfg.bEnabled;
-#endif
+#endif*/
 
         return TRUE;
     }


### PR DESCRIPTION
Reason for change: Functional purpose of Device.DHCPv6.Client.1.Enable is enabled in DHCPMgr enabled devices alone and in other devices, for now it will be used to collect status of v6 client. Test Procedure: No New v6 client related regressions should be observed in Technicolor Devices Risks: High
Priority: P0
Signed-off-by:BudimeVigneshwar_Prasad@comcast.com

Change-Id: Ied32ab2a0a78334fd3944aad91a8f15ba73e783f