### PR TITLE
SHARMAN-2642 : DNS resolution fails after recovering from WAN outage

### DIFF
--- a/source/WanManager/wanmgr_interface_sm.c
+++ b/source/WanManager/wanmgr_interface_sm.c
@@ -698,21 +698,16 @@ int wan_updateDNS(WanMgr_IfaceSM_Controller_t* pWanIfaceCtrl, BOOL addIPv4, BOOL
         sysevent_set(sysevent_fd, sysevent_token, SYSEVENT_FIELD_IPV6_DNS_PRIMARY, "", 0);
         sysevent_set(sysevent_fd, sysevent_token, SYSEVENT_FIELD_IPV6_DNS_SECONDARY, "", 0);
 
-        // if there was any previously configured DNS for selected interface, restart LAN side DHCP server
-        if ( strlen(v4nameserver1) > 0 || strlen(v4nameserver2) > 0
-                || strlen(v6nameserver1) > 0 || strlen (v6nameserver2) > 0)
-        {
-            // new and curr nameservers are different, so apply configuration
-            CcspTraceInfo(("%s %d: Setting %s\n", __FUNCTION__, __LINE__, SYSEVENT_DHCP_SERVER_RESTART));
-            sysevent_set(sysevent_fd, sysevent_token, SYSEVENT_DHCP_SERVER_RESTART, NULL, 0);
-        }
-
         if (fp != NULL)
         {
             CcspTraceError(("%s %d - No valid nameserver is available, adding loopback address for nameserver\n", __FUNCTION__,__LINE__));
             fprintf(fp, "nameserver %s \n", LOOPBACK);
             fclose(fp);
         }
+
+        // new and curr nameservers are different, so apply configuration
+        CcspTraceInfo(("%s %d: Setting %s\n", __FUNCTION__, __LINE__, SYSEVENT_DHCP_SERVER_RESTART));
+        sysevent_set(sysevent_fd, sysevent_token, SYSEVENT_DHCP_SERVER_RESTART, NULL, 0);
         return RETURN_OK;
     }
 


### PR DESCRIPTION
Reason for change:  DNS servers were not cleared properly during WAN tear down
Test Procedure: NA
Risks: Low

Change-Id: Iabd31e28d62865847fd0e62aff3ad61c92dfe3af