### PR TITLE
CMFSUPPORT-1635 : Open sourcing RdkWanManager component.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,5 @@
 ##########################################################################
-# If not stated otherwise in this file or this component's Licenses.txt
+# If not stated otherwise in this file or this component's LICENSE
 # file the following copyright and licenses apply:
 #
 # Copyright 2020 RDK Management

--- a/cfg/Makefile.am
+++ b/cfg/Makefile.am
@@ -1,5 +1,5 @@
 ##########################################################################
-# If not stated otherwise in this file or this component's Licenses.txt
+# If not stated otherwise in this file or this component's LICENSE
 # file the following copyright and licenses apply:
 #
 # Copyright 2020 RDK Management

--- a/config/RdkWanManager.xml
+++ b/config/RdkWanManager.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!--
- If not stated otherwise in this file or this component's Licenses.txt file the
+ If not stated otherwise in this file or this component's LICENSE file the
  following copyright and licenses apply:
 
  Copyright 2020 RDK Management

--- a/config/RdkWanManager_v2.xml
+++ b/config/RdkWanManager_v2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!--
- If not stated otherwise in this file or this component's Licenses.txt file the
+ If not stated otherwise in this file or this component's LICENSE file the
  following copyright and licenses apply:
 
  Copyright 2020 RDK Management

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 ##########################################################################
-# If not stated otherwise in this file or this component's Licenses.txt
+# If not stated otherwise in this file or this component's LICENSE
 # file the following copyright and licenses apply:
 #
 # Copyright 2020 RDK Management

--- a/source/Makefile.am
+++ b/source/Makefile.am
@@ -1,5 +1,5 @@
 ##########################################################################
-# If not stated otherwise in this file or this component's Licenses.txt
+# If not stated otherwise in this file or this component's LICENSE
 # file the following copyright and licenses apply:
 #
 # Copyright 2020 RDK Management

--- a/source/TR-181/Makefile.am
+++ b/source/TR-181/Makefile.am
@@ -1,5 +1,5 @@
 ##########################################################################
-# If not stated otherwise in this file or this component's Licenses.txt
+# If not stated otherwise in this file or this component's LICENSE
 # file the following copyright and licenses apply:
 #
 # Copyright 2020 RDK Management

--- a/source/TR-181/include/dmsb_tr181_psm_definitions.h
+++ b/source/TR-181/include/dmsb_tr181_psm_definitions.h
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/TR-181/include/wanmgr_apis.h
+++ b/source/TR-181/include/wanmgr_apis.h
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/TR-181/include/wanmgr_dml.h
+++ b/source/TR-181/include/wanmgr_dml.h
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/TR-181/include/wanmgr_webconfig.h
+++ b/source/TR-181/include/wanmgr_webconfig.h
@@ -1,5 +1,5 @@
  /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/TR-181/include/wanmgr_webconfig_apis.h
+++ b/source/TR-181/include/wanmgr_webconfig_apis.h
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/TR-181/middle_layer_src/Makefile.am
+++ b/source/TR-181/middle_layer_src/Makefile.am
@@ -1,5 +1,5 @@
 ##########################################################################
-# If not stated otherwise in this file or this component's Licenses.txt
+# If not stated otherwise in this file or this component's LICENSE
 # file the following copyright and licenses apply:
 #
 # Copyright 2020 RDK Management

--- a/source/TR-181/middle_layer_src/wanmgr_bus_utils.h
+++ b/source/TR-181/middle_layer_src/wanmgr_bus_utils.h
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/TR-181/middle_layer_src/wanmgr_dml_apis.c
+++ b/source/TR-181/middle_layer_src/wanmgr_dml_apis.c
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/TR-181/middle_layer_src/wanmgr_dml_apis.h
+++ b/source/TR-181/middle_layer_src/wanmgr_dml_apis.h
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/TR-181/middle_layer_src/wanmgr_dml_dhcpv4.c
+++ b/source/TR-181/middle_layer_src/wanmgr_dml_dhcpv4.c
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/TR-181/middle_layer_src/wanmgr_dml_dhcpv4.h
+++ b/source/TR-181/middle_layer_src/wanmgr_dml_dhcpv4.h
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/TR-181/middle_layer_src/wanmgr_dml_dhcpv6.c
+++ b/source/TR-181/middle_layer_src/wanmgr_dml_dhcpv6.c
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/TR-181/middle_layer_src/wanmgr_dml_dhcpv6.h
+++ b/source/TR-181/middle_layer_src/wanmgr_dml_dhcpv6.h
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/TR-181/middle_layer_src/wanmgr_dml_iface_apis.c
+++ b/source/TR-181/middle_layer_src/wanmgr_dml_iface_apis.c
@@ -1,6 +1,6 @@
 #if !defined(WAN_MANAGER_UNIFICATION_ENABLED)
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/TR-181/middle_layer_src/wanmgr_dml_iface_apis.h
+++ b/source/TR-181/middle_layer_src/wanmgr_dml_iface_apis.h
@@ -1,6 +1,6 @@
 #if !defined(WAN_MANAGER_UNIFICATION_ENABLED)
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/TR-181/middle_layer_src/wanmgr_dml_iface_v2_apis.c
+++ b/source/TR-181/middle_layer_src/wanmgr_dml_iface_v2_apis.c
@@ -1,6 +1,6 @@
 #if defined(WAN_MANAGER_UNIFICATION_ENABLED)
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2023 RDK Management

--- a/source/TR-181/middle_layer_src/wanmgr_dml_iface_v2_apis.h
+++ b/source/TR-181/middle_layer_src/wanmgr_dml_iface_v2_apis.h
@@ -1,6 +1,6 @@
 #if defined(WAN_MANAGER_UNIFICATION_ENABLED)
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2023 RDK Management

--- a/source/TR-181/middle_layer_src/wanmgr_plugin_main.c
+++ b/source/TR-181/middle_layer_src/wanmgr_plugin_main.c
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/TR-181/middle_layer_src/wanmgr_plugin_main.h
+++ b/source/TR-181/middle_layer_src/wanmgr_plugin_main.h
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/TR-181/middle_layer_src/wanmgr_plugin_main_apis.c
+++ b/source/TR-181/middle_layer_src/wanmgr_plugin_main_apis.c
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/TR-181/middle_layer_src/wanmgr_plugin_main_apis.h
+++ b/source/TR-181/middle_layer_src/wanmgr_plugin_main_apis.h
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/TR-181/middle_layer_src/wanmgr_rdkbus_apis.c
+++ b/source/TR-181/middle_layer_src/wanmgr_rdkbus_apis.c
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/TR-181/middle_layer_src/wanmgr_rdkbus_apis.h
+++ b/source/TR-181/middle_layer_src/wanmgr_rdkbus_apis.h
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/TR-181/middle_layer_src/wanmgr_rdkbus_common.h
+++ b/source/TR-181/middle_layer_src/wanmgr_rdkbus_common.h
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/TR-181/middle_layer_src/wanmgr_rdkbus_utils.c
+++ b/source/TR-181/middle_layer_src/wanmgr_rdkbus_utils.c
@@ -1,5 +1,5 @@
 /*
-   If not stated otherwise in this file or this component's Licenses.txt file the
+   If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/TR-181/middle_layer_src/wanmgr_rdkbus_utils.h
+++ b/source/TR-181/middle_layer_src/wanmgr_rdkbus_utils.h
@@ -2,7 +2,7 @@
 #define _WANMGR_RDKBUS_UTILS_H_
 
 /*
-   If not stated otherwise in this file or this component's Licenses.txt file the
+   If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/TR-181/netmonitor/Makefile.am
+++ b/source/TR-181/netmonitor/Makefile.am
@@ -1,5 +1,5 @@
 ##########################################################################
-# If not stated otherwise in this file or this component's Licenses.txt
+# If not stated otherwise in this file or this component's LICENSE
 # file the following copyright and licenses apply:
 #
 # Copyright 2020 RDK Management

--- a/source/TR-181/netmonitor/network_route_monitor.c
+++ b/source/TR-181/netmonitor/network_route_monitor.c
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2024 RDK Management

--- a/source/TR-181/netmonitor/network_route_monitor.h
+++ b/source/TR-181/netmonitor/network_route_monitor.h
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2024 RDK Management

--- a/source/WanManager/Makefile.am
+++ b/source/WanManager/Makefile.am
@@ -1,5 +1,5 @@
 ##########################################################################
-# If not stated otherwise in this file or this component's Licenses.txt
+# If not stated otherwise in this file or this component's LICENSE
 # file the following copyright and licenses apply:
 #
 # Copyright 2020 RDK Management

--- a/source/WanManager/wanmgr_controller.c
+++ b/source/WanManager/wanmgr_controller.c
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/WanManager/wanmgr_controller.h
+++ b/source/WanManager/wanmgr_controller.h
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/WanManager/wanmgr_core.c
+++ b/source/WanManager/wanmgr_core.c
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/WanManager/wanmgr_core.h
+++ b/source/WanManager/wanmgr_core.h
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/WanManager/wanmgr_data.c
+++ b/source/WanManager/wanmgr_data.c
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/WanManager/wanmgr_data.h
+++ b/source/WanManager/wanmgr_data.h
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/WanManager/wanmgr_dhcpv4_internal.c
+++ b/source/WanManager/wanmgr_dhcpv4_internal.c
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/WanManager/wanmgr_dhcpv4_internal.h
+++ b/source/WanManager/wanmgr_dhcpv4_internal.h
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/WanManager/wanmgr_dhcpv6_internal.c
+++ b/source/WanManager/wanmgr_dhcpv6_internal.c
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/WanManager/wanmgr_dhcpv6_internal.h
+++ b/source/WanManager/wanmgr_dhcpv6_internal.h
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/WanManager/wanmgr_interface_sm.c
+++ b/source/WanManager/wanmgr_interface_sm.c
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/WanManager/wanmgr_interface_sm.h
+++ b/source/WanManager/wanmgr_interface_sm.h
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/WanManager/wanmgr_ipc.c
+++ b/source/WanManager/wanmgr_ipc.c
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/WanManager/wanmgr_ipc.h
+++ b/source/WanManager/wanmgr_ipc.h
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/WanManager/wanmgr_main.c
+++ b/source/WanManager/wanmgr_main.c
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/WanManager/wanmgr_net_utils.c
+++ b/source/WanManager/wanmgr_net_utils.c
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/WanManager/wanmgr_net_utils.h
+++ b/source/WanManager/wanmgr_net_utils.h
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/WanManager/wanmgr_platform_events.h
+++ b/source/WanManager/wanmgr_platform_events.h
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/WanManager/wanmgr_policy_auto_impl.c
+++ b/source/WanManager/wanmgr_policy_auto_impl.c
@@ -1,5 +1,5 @@
 /*
-   If not stated otherwise in this file or this component's Licenses.txt file the
+   If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/WanManager/wanmgr_policy_autowan_impl.c
+++ b/source/WanManager/wanmgr_policy_autowan_impl.c
@@ -1,5 +1,5 @@
 /*
-   If not stated otherwise in this file or this component's Licenses.txt file the
+   If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2019 RDK Management

--- a/source/WanManager/wanmgr_policy_fm_impl.c
+++ b/source/WanManager/wanmgr_policy_fm_impl.c
@@ -1,5 +1,5 @@
 /*
-   If not stated otherwise in this file or this component's Licenses.txt file the
+   If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/WanManager/wanmgr_policy_fmob_impl.c
+++ b/source/WanManager/wanmgr_policy_fmob_impl.c
@@ -1,5 +1,5 @@
 /*
-   If not stated otherwise in this file or this component's Licenses.txt file the
+   If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/WanManager/wanmgr_policy_parallel_scan_impl.c
+++ b/source/WanManager/wanmgr_policy_parallel_scan_impl.c
@@ -1,5 +1,5 @@
 /*
-   If not stated otherwise in this file or this component's Licenses.txt file the
+   If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/WanManager/wanmgr_policy_pp_impl.c
+++ b/source/WanManager/wanmgr_policy_pp_impl.c
@@ -1,5 +1,5 @@
 /*
-   If not stated otherwise in this file or this component's Licenses.txt file the
+   If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/WanManager/wanmgr_policy_ppob_impl.c
+++ b/source/WanManager/wanmgr_policy_ppob_impl.c
@@ -1,5 +1,5 @@
 /*
-   If not stated otherwise in this file or this component's Licenses.txt file the
+   If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/WanManager/wanmgr_ssp_action.c
+++ b/source/WanManager/wanmgr_ssp_action.c
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/WanManager/wanmgr_ssp_global.h
+++ b/source/WanManager/wanmgr_ssp_global.h
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/WanManager/wanmgr_ssp_internal.h
+++ b/source/WanManager/wanmgr_ssp_internal.h
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/WanManager/wanmgr_ssp_messagebus_interface.c
+++ b/source/WanManager/wanmgr_ssp_messagebus_interface.c
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/WanManager/wanmgr_ssp_messagebus_interface.h
+++ b/source/WanManager/wanmgr_ssp_messagebus_interface.h
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/WanManager/wanmgr_sysevents.c
+++ b/source/WanManager/wanmgr_sysevents.c
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/WanManager/wanmgr_sysevents.h
+++ b/source/WanManager/wanmgr_sysevents.h
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/WanManager/wanmgr_utils.c
+++ b/source/WanManager/wanmgr_utils.c
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/WanManager/wanmgr_utils.h
+++ b/source/WanManager/wanmgr_utils.h
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/WanManager/wanmgr_wan_failover.c
+++ b/source/WanManager/wanmgr_wan_failover.c
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/WanManager/wanmgr_wan_failover.h
+++ b/source/WanManager/wanmgr_wan_failover.h
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/WanManager/wanmgr_webconfig.c
+++ b/source/WanManager/wanmgr_webconfig.c
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management

--- a/source/WanManager/wanmgr_webconfig_apis.c
+++ b/source/WanManager/wanmgr_webconfig_apis.c
@@ -1,6 +1,6 @@
 
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2020 RDK Management


### PR DESCRIPTION
Reason for change:
As per apache licence header we need to use LICENSE file instead of Licenses.txt file as we mentioned in all the headers. so we need to replace LICENSE with Licenses.txt.

Test Procedure: NA
Risks: Low