### PR TITLE
RDKCOM-4774: RDKBDEV-2643: use sysctl_iface_set() to write to /proc

### DIFF
--- a/source/WanManager/wanmgr_net_utils.c
+++ b/source/WanManager/wanmgr_net_utils.c
@@ -1076,16 +1076,14 @@ int WanManager_ProcessMAPTConfiguration(ipc_mapt_data_t *dhcp6cMAPTMsgBody, WANM
 #endif  //IVI_MULTI_BRIDGE_SUPPORT
 #endif  //IVI_KERNEL_SUPPORT
 
-    snprintf(cmdDisableMapFiltering, sizeof(cmdDisableMapFiltering), "echo 0 > /proc/sys/net/ipv4/conf/%s/rp_filter", vlanIf);
-
 #ifdef FEATURE_MAPT_DEBUG
-    MaptInfo("mapt: Disable RP Filtering:%s", cmdDisableMapFiltering);
+    MaptInfo("mapt: Disable RP Filtering: echo 0 > /proc/sys/net/ipv4/conf/%s/rp_filter", vlanIf);
 #endif
 
-    if ((ret = WanManager_DoSystemActionWithStatus("mapt", cmdDisableMapFiltering)) < RETURN_OK)
+    if (sysctl_iface_set("/proc/sys/net/ipv4/conf/%s/rp_filter", vlanIf, "0") != 0)
     {
-        CcspTraceError(("Failed to run: %s:%d", cmdDisableMapFiltering, ret));
-        return ret;
+        CcspTraceError(("%s-%d : Failure writing to /proc file\n", __FUNCTION__, __LINE__));
+        return RETURN_ERR;
     }
 
 #ifdef NAT46_KERNEL_SUPPORT

--- a/source/WanManager/wanmgr_sysevents.c
+++ b/source/WanManager/wanmgr_sysevents.c
@@ -982,14 +982,14 @@ static int do_toggle_v6_status (void)
     {
         CcspTraceInfo(("%s %d toggle initiated\n", __FUNCTION__, __LINE__));
 
-        ret = v_secure_system("sysctl -w net.ipv6.conf.%s.disable_ipv6=1", wanInterface);
-        if (ret != 0) {
-            CcspTraceWarning(("%s %d: Failure in executing command via v_secure_system. ret:[%d]\n", __FUNCTION__, __LINE__, ret));
+        if (sysctl_iface_set("/proc/sys/net/ipv6/conf/%s/disable_ipv6", wanInterface, "1") != 0)
+        {
+            CcspTraceWarning(("%s-%d : Failure writing to /proc file\n", __FUNCTION__, __LINE__));
         }
 
-        ret = v_secure_system("sysctl -w net.ipv6.conf.%s.disable_ipv6=0", wanInterface);
-        if (ret != 0) {
-            CcspTraceWarning(("%s %d: Failure in executing command via v_secure_system. ret:[%d]\n", __FUNCTION__, __LINE__, ret));
+        if (sysctl_iface_set("/proc/sys/net/ipv6/conf/%s/disable_ipv6", wanInterface, "0") != 0)
+        {
+            CcspTraceWarning(("%s-%d : Failure writing to /proc file\n", __FUNCTION__, __LINE__));
         }
     }
 
@@ -1007,14 +1007,14 @@ int Force_IPv6_toggle (char* wanInterface)
     int ret = 0;
     CcspTraceInfo(("%s %d force toggle initiated\n", __FUNCTION__, __LINE__));
 
-    ret = v_secure_system("sysctl -w net.ipv6.conf.%s.disable_ipv6=1", wanInterface);
-    if (ret != 0) {
-        CcspTraceWarning(("%s %d: Failure in executing command via v_secure_system. ret:[%d]\n", __FUNCTION__, __LINE__, ret));
+    if (sysctl_iface_set("/proc/sys/net/ipv6/conf/%s/disable_ipv6", wanInterface, "1") != 0)
+    {
+        CcspTraceWarning(("%s-%d : Failure writing to /proc file\n", __FUNCTION__, __LINE__));
     }
 
-    ret = v_secure_system("sysctl -w net.ipv6.conf.%s.disable_ipv6=0", wanInterface);
-    if (ret != 0) {
-        CcspTraceWarning(("%s %d: Failure in executing command via v_secure_system. ret:[%d]\n", __FUNCTION__, __LINE__, ret));
+    if (sysctl_iface_set("/proc/sys/net/ipv6/conf/%s/disable_ipv6", wanInterface, "0") != 0)
+    {
+        CcspTraceWarning(("%s-%d : Failure writing to /proc file\n", __FUNCTION__, __LINE__));
     }
     sysevent_set(sysevent_fd, sysevent_token, SYSEVENT_IPV6_TOGGLE, "FALSE", 0); //Reset toggle flag to false.
 

--- a/source/WanManager/wanmgr_utils.c
+++ b/source/WanManager/wanmgr_utils.c
@@ -23,6 +23,9 @@
 #include <errno.h>
 #include <sys/sysinfo.h>
 #include <sys/wait.h>  /* for waitpid */
+#include <sys/stat.h>
+#include <fcntl.h>
+
 #include "wanmgr_utils.h"
 #include "ipc_msg.h"
 
@@ -1095,4 +1098,35 @@ ANSC_STATUS WanMgr_RestartUpdateCfg_Bool (const char * param, int idx, BOOL* out
         return ANSC_STATUS_FAILURE;
     }
     return ANSC_STATUS_SUCCESS;
+}
+
+int sysctl_iface_set(const char *path, const char *ifname, const char *content)
+{
+    char buf[128];
+    char *filename;
+    size_t len;
+    int fd;
+
+    if (ifname) {
+        snprintf(buf, sizeof(buf), path, ifname);
+        filename = buf;
+    }
+    else
+        filename = path;
+
+    if ((fd = open(filename, O_WRONLY)) < 0) {
+        perror("Failed to open file");
+        return -1;
+    }
+
+    len = strlen(content);
+    if (write(fd, content, len) != (ssize_t) len) {
+        perror("Failed to write to file");
+        close(fd);
+        return -1;
+    }
+
+    close(fd);
+
+    return 0;
 }

--- a/source/WanManager/wanmgr_utils.h
+++ b/source/WanManager/wanmgr_utils.h
@@ -159,4 +159,7 @@ int WanMgr_SetRestartWanInfo (const char * param, int idx, char * value);
 
 ANSC_STATUS WanMgr_RestartUpdateCfg (const char * param, int idx, char * output, int size);
 ANSC_STATUS WanMgr_RestartUpdateCfg_Bool (const char * param, int idx, BOOL* output);
+
+int sysctl_iface_set(const char *path, const char *ifname, const char *content);
+
 #endif /* _WANMGR_UTILS_H_ */


### PR DESCRIPTION
Reason for change:
use sysctl_iface_set() to write to /proc files
Test Procedure: Sanity.
Risks: None.
Signed-off-by: Andre McCurdy <armccurdy@gmail.com>
Priority: P1

Change-Id: Id49e9264a2c53e103f03fa95f68b43f30c63f20e