### PR TITLE
RDKCOM-4775: RDKBDEV-2644: fix return value from void

### DIFF
--- a/source/WanManager/wanmgr_dhcpv4_apis.c
+++ b/source/WanManager/wanmgr_dhcpv4_apis.c
@@ -454,8 +454,6 @@ void WanMgr_UpdateIpFromCellularMgr (WanMgr_IfaceSM_Controller_t* pWanIfaceCtrl)
             close(sock);
         }
     }
-
-    return;
 }
 
 ANSC_STATUS IPCPStateChangeHandler (DML_VIRTUAL_IFACE* pVirtIf) 


### PR DESCRIPTION
Reason for change:
fix return value from void function WanMgr_UpdateIpFromCellularMgr() Test Procedure: Sanity.
Risks: None.
Signed-off-by: Andre McCurdy <armccurdy@gmail.com>
Priority: P1

Change-Id: I3021ff5d4baa3163d5c412290105e429b4baf95d