### PR TITLE
RDKCOM-4479: REFPLTB-2590 : [TDK][AUTO][RPI] WANInterfaceNumberOfEntries value is...

### DIFF
--- a/source/TR-181/middle_layer_src/wanmgr_rdkbus_apis.c
+++ b/source/TR-181/middle_layer_src/wanmgr_rdkbus_apis.c
@@ -266,7 +266,7 @@ int get_Virtual_Interface_FromPSM(ULONG instancenum, ULONG virtInsNum ,DML_VIRTU
         pVirtIf->Enable = TRUE;
     }
 
-#if defined(FEATURE_RDKB_CONFIGURABLE_WAN_INTERFACE) /* TODO: This is a workaround for the platforms using same Wan Name.*/
+#if defined(FEATURE_RDKB_CONFIGURABLE_WAN_INTERFACE) || defined(_PLATFORM_RASPBERRYPI_)/* TODO: This is a workaround for the platforms using same Wan Name.*/
     _ansc_memset(param_name, 0, sizeof(param_name));
     _ansc_memset(param_value, 0, sizeof(param_value));
     _ansc_sprintf(param_name, PSM_WANMANAGER_IF_VIRIF_NAME, instancenum, (virtInsNum + 1));


### PR DESCRIPTION
Reason for change : When RPI flag is enabled, param_value is getting called which is having the interface name 'erouter0'
Test Procedure : Able to see WANInterfaceNumberOfEntries DM is getting updated with '1'
Risks : Low
Signed-off-by: kosikasaipriya <kosika.saipriya@ltts.com>

Reason for change: REFPLTB-2590 : [TDK][AUTO][RPI] WANInterfaceNumberOfEntries val...
Test Procedure: None.
Risks: Low.
Priority: P1

Change-Id: I4c7b6fd4f007155e6e7c7592fa7cc6e8c719eb18