### PR TITLE
RDKCOM-4490: RDKBDEV-2282: Handling Voice Interface IP (X_RDK_BoundIpAddr)

### DIFF
--- a/source/WanManager/wanmgr_interface_sm.c
+++ b/source/WanManager/wanmgr_interface_sm.c
@@ -39,6 +39,7 @@
 #include <telemetry_busmessage_sender.h>
 #endif
 
+#define IF_SIZE      32
 #define LOOP_TIMEOUT 50000 // timeout in microseconds. This is the state machine loop interval
 #define RESOLV_CONF_FILE "/etc/resolv.conf"
 #define LOOPBACK "127.0.0.1"
@@ -989,10 +990,11 @@ static int checkIpv6AddressAssignedToBridge(char *IfaceName)
 }
 
 
-static void updateInterfaceToVoiceManager(WanMgr_IfaceSM_Controller_t* pWanIfaceCtrl)
+static void updateInterfaceToVoiceManager(WanMgr_IfaceSM_Controller_t* pWanIfaceCtrl, bool voip_started)
 {
     ANSC_STATUS retStatus        = ANSC_STATUS_FAILURE;
     bool isUpdate                = false;
+    char voipIfName[IF_SIZE]     = {0};
 
     if((NULL == pWanIfaceCtrl) || (NULL == pWanIfaceCtrl->pIfaceData))
     {
@@ -1007,10 +1009,20 @@ static void updateInterfaceToVoiceManager(WanMgr_IfaceSM_Controller_t* pWanIface
     {
         /* Update VOIP vlan name to TelcoVoiceManager */
         isUpdate = true;
+
+	// Update the Interface name after auto wan sesning is complete.
+        // When interface is down (due to cable removal etc) set Interface name to empty string
+        if (voip_started)
+            strncpy(voipIfName, p_VirtIf->Name, sizeof(voipIfName));
     }
     else if(0 == strcmp("DATA", p_VirtIf->Alias))
     {
         isUpdate = true;
+
+        // Update the Interface name after auto wan sesning is complete.
+        // When interface is down (due to cable removal etc) set Interface name to empty string
+        if (voip_started)
+            strncpy(voipIfName, "erouter0", sizeof(voipIfName));
 
         /* If there is a VOIP interface present, then do not update DATA vlan name to TelecoVoiceManager. */
         for(int virIf_id=0; virIf_id< pWanIfaceData->NoOfVirtIfs; virIf_id++)
@@ -2039,8 +2051,11 @@ static eWanState_t wan_transition_ipv4_up(WanMgr_IfaceSM_Controller_t* pWanIface
     p_VirtIf->Status = WAN_IFACE_STATUS_UP;
 
 #if defined(_DT_WAN_Manager_Enable_)
-    /* Update voice interface name to TelcoVoiceManager */
-    updateInterfaceToVoiceManager(pWanIfaceCtrl);
+    if ((0 == strcmp("DATA", p_VirtIf->Alias)) || (0 == strcmp("VOIP", p_VirtIf->Alias)))
+    {
+        /* Update voice interface name to TelcoVoiceManager */
+        updateInterfaceToVoiceManager(pWanIfaceCtrl, true);
+    }
 
     if(strcmp(p_VirtIf->Alias, "DATA"))
     {
@@ -2304,8 +2319,11 @@ static eWanState_t wan_transition_ipv6_up(WanMgr_IfaceSM_Controller_t* pWanIface
     p_VirtIf->Status = WAN_IFACE_STATUS_UP;
 
 #if defined(_DT_WAN_Manager_Enable_)
-    /* Update voice interface name to TelcoVoiceManager */
-    updateInterfaceToVoiceManager(pWanIfaceCtrl);
+    if ((0 == strcmp("DATA", p_VirtIf->Alias)) || (0 == strcmp("VOIP", p_VirtIf->Alias)))
+    {
+        /* Update voice interface name to TelcoVoiceManager */
+        updateInterfaceToVoiceManager(pWanIfaceCtrl, true);
+    }
 #endif
     if (pWanIfaceCtrl->interfaceIdx != -1)
     {
@@ -3012,6 +3030,12 @@ static eWanState_t wan_state_obtaining_ip_addresses(WanMgr_IfaceSM_Controller_t*
         p_VirtIf->PPP.LinkStatus ==  WAN_IFACE_PPP_LINK_STATUS_CONFIGURING ||
         p_VirtIf->Reset == TRUE)
     {
+        if ((0 == strcmp("DATA", p_VirtIf->Alias)) || (0 == strcmp("VOIP", p_VirtIf->Alias)))
+        {
+            /* Update voice interface name to TelcoVoiceManager */
+            updateInterfaceToVoiceManager(pWanIfaceCtrl, false);
+        }
+
         return wan_transition_physical_interface_down(pWanIfaceCtrl);
     }
 
@@ -3027,6 +3051,13 @@ static eWanState_t wan_state_obtaining_ip_addresses(WanMgr_IfaceSM_Controller_t*
     {
         CcspTraceInfo(("%s %d VlanDiscovery timer expired Or VLAN/PPP status DOWN \n", __FUNCTION__, __LINE__));
         p_VirtIf->VLAN.Expired = TRUE;
+
+        if ((0 == strcmp("DATA", p_VirtIf->Alias)) || (0 == strcmp("VOIP", p_VirtIf->Alias)))
+        {
+            /* Update voice interface name to TelcoVoiceManager */
+            updateInterfaceToVoiceManager(pWanIfaceCtrl, false);
+        }
+
         return wan_transition_physical_interface_down(pWanIfaceCtrl);
     }
 

--- a/source/WanManager/wanmgr_policy_auto_impl.c
+++ b/source/WanManager/wanmgr_policy_auto_impl.c
@@ -796,6 +796,8 @@ static WcAwPolicyState_t Transition_InterfaceValidated (WanMgr_Policy_Controller
                     __FUNCTION__, __LINE__, pWanController->activeInterfaceIdx));
     }
 
+    sysevent_set(sysevent_fd, sysevent_token, "voip-status", "started", 0);
+
     CcspTraceInfo(("%s %d: setting GroupSelectedInterface(%d) \n", __FUNCTION__, __LINE__, pWanController->activeInterfaceIdx));
     if (WanMgr_SetGroupSelectedIface (pWanController->GroupInst, (pWanController->activeInterfaceIdx+1)) != ANSC_STATUS_SUCCESS)
     {


### PR DESCRIPTION


Reason for change:
- Wanmanager selects the WAN type and has the voice interface information.
- Wanmanager should update the Voice interface name to TelcoVoiceManager. Test Procedure: Please refer JIRA attachment for detailed test steps Risks: None

Signed-off-by: Sherik Sensin A <sherik.a@t-systems.com>
Priority: P1

Change-Id: I937d5c157e7993ce1120b2133e0c5021fe1f8b8f