### PR TITLE
RDKCOM-4784: RDKBDEV-2642 fix incorrect change to support 64bit

### DIFF
--- a/source/TR-181/middle_layer_src/wanmgr_dml_apis.c
+++ b/source/TR-181/middle_layer_src/wanmgr_dml_apis.c
@@ -189,7 +189,8 @@ BOOL WanManager_SetParamStringValue(ANSC_HANDLE hInsContext, char* ParamName, ch
         if (strcmp(ParamName, "Data") == 0)
         {
             char *webConf = NULL;
-            ULONG webSize = 0;
+            size_t webSize = 0;
+
             webConf = AnscBase64Decode(pString, &webSize);
             if(!webConf)
             {
@@ -212,7 +213,7 @@ BOOL WanManager_SetParamStringValue(ANSC_HANDLE hInsContext, char* ParamName, ch
         else if (strcmp(ParamName, "WanFailoverData") == 0)
         {
             char *webConf = NULL;
-            ULONG webSize = 0;
+            size_t webSize = 0;
 
             webConf = AnscBase64Decode(pString, &webSize);
             if(!webConf)


### PR DESCRIPTION
Reason for change:
fix incorrect change to support 64bit targets

It's not valid to cast a pointer to a 32bit value to be a pointer to a 64bit value.

Test Procedure: Sanity.
Risks: None.
Signed-off-by: Andre McCurdy <armccurdy@gmail.com>

Change-Id: I9d7a0c695423986f0574cefd73eee45ac57cafa5