### PR TITLE
RDKDEV-1046 : Fix DHCPv6 dynamic duid issue

### DIFF
--- a/source/WanManager/wanmgr_dhcpv6_apis.c
+++ b/source/WanManager/wanmgr_dhcpv6_apis.c
@@ -361,14 +361,12 @@ static int _prepare_client_conf(PDML_DHCPCV6_CFG       pCfg)
 #if defined(_DT_WAN_Manager_Enable_)
         fprintf(fp, "log-level 7\n");
         fprintf(fp, "log-mode full\n");
-        fprintf(fp, "duid-type duid-ll\n");
         fprintf(fp, "script \"%s\" \n", CLIENT_NOTIFY);
         fprintf(fp, "reconfigure-accept 1\n");
 #else
-        fprintf(fp, "duid-type duid-ll\n");
         fprintf(fp, "notify-scripts\n");
 #endif
-
+        fprintf(fp, "duid-type duid-ll\n");
         fprintf(fp, "iface %s {\n", pCfg->Interface);
 
         if (pCfg->RapidCommit)

--- a/source/WanManager/wanmgr_dhcpv6_apis.c
+++ b/source/WanManager/wanmgr_dhcpv6_apis.c
@@ -365,6 +365,7 @@ static int _prepare_client_conf(PDML_DHCPCV6_CFG       pCfg)
         fprintf(fp, "script \"%s\" \n", CLIENT_NOTIFY);
         fprintf(fp, "reconfigure-accept 1\n");
 #else
+        fprintf(fp, "duid-type duid-ll\n");
         fprintf(fp, "notify-scripts\n");
 #endif
 


### PR DESCRIPTION
Reason for change: DHCPv6 provisioning fails with dynamic DUID
Test Procedure: Check that DUID remains the same over reboots
Risks: None

Signed-off-by: Pavlov Andrey apavlov@maxlinear.com