### PR TITLE
RDKB-55511: Remove RDKB api dependancy from DHCPv4 HAL

### DIFF
--- a/source/WanManager/wanmgr_data.c
+++ b/source/WanManager/wanmgr_data.c
@@ -1027,3 +1027,27 @@ DML_VIRTUAL_IFACE* WanMgr_GetVirtIfDataByAlias_locked(char* Alias)
     return NULL;
 }
 
+/* WanMgr_GetVirtIfData ()
+ * This function checks all the Interfaces and retuns the active Virtual interface.
+ */
+DML_VIRTUAL_IFACE* WanMgr_GetActiveVirtIfData_locked(void)
+{
+    UINT idx = 0;
+
+    if(pthread_mutex_lock(&gWanMgrDataBase.gDataMutex) == 0)
+    {
+        WanMgr_IfaceCtrl_Data_t* pWanIfaceCtrl = &(gWanMgrDataBase.IfaceCtrl);
+        if(pWanIfaceCtrl->pIface != NULL)
+        {
+            for(idx = 0; idx < pWanIfaceCtrl->ulTotalNumbWanInterfaces; idx++)
+            {
+                DML_WAN_IFACE* pWanIfaceData = &(pWanIfaceCtrl->pIface[idx]);
+                if(pWanIfaceData->Selection.Status == WAN_IFACE_ACTIVE){
+                    return pWanIfaceData->VirtIfList;
+                }
+            }
+        }
+        WanMgrDml_GetIfaceData_release(NULL);
+    }
+    return NULL;
+}

--- a/source/WanManager/wanmgr_data.h
+++ b/source/WanManager/wanmgr_data.h
@@ -79,6 +79,7 @@ void WanMgr_VlanIfaceMutex_release(DML_VLAN_IFACE_TABLE* vlanIf);
 DML_VIRTIF_MARKING* WanMgr_getVirtualMarking_locked(UINT baseIfidx, UINT virtIfIdx, UINT Markingid);
 void WanMgr_VirtMarkingMutex_release(DML_VIRTIF_MARKING* virtMarking);
 DML_VIRTUAL_IFACE* WanMgr_GetVirtIfDataByAlias_locked(char* iface_name);
+DML_VIRTUAL_IFACE* WanMgr_GetActiveVirtIfData_locked(void);
 WANMGR_IFACE_GROUP* WanMgr_GetIfaceGroup_locked(UINT iface_index);
 void WanMgrDml_GetIfaceGroup_release(void);
 ANSC_STATUS WanMgr_UpdatePrevData(void);

--- a/source/WanManager/wanmgr_dhcpv4_apis.c
+++ b/source/WanManager/wanmgr_dhcpv4_apis.c
@@ -890,10 +890,12 @@ WanMgr_DmlDhcpcGetCfg
     sprintf(pCfg->Alias,"eRouter");
     pCfg->bEnabled = TRUE;
     pCfg->InstanceNumber = 1;
-    if(dhcpv4c_get_ert_ifname(ifname))
-        pCfg->Interface[0] = 0;
-    else
-        snprintf(pCfg->Interface, sizeof(pCfg->Interface)-1, "%s", ifname);
+
+    DML_VIRTUAL_IFACE *p_VirtIf = WanMgr_GetActiveVirtIfData_locked();
+    if(p_VirtIf != NULL){
+        snprintf(pCfg->Interface, sizeof(pCfg->Interface), "%s", p_VirtIf->IP.Ipv4Data.ifname);
+        WanMgrDml_GetIfaceData_release(NULL);
+    }
     pCfg->PassthroughEnable = TRUE;
     pCfg->PassthroughDHCPPool[0] = 0;
 
@@ -909,34 +911,27 @@ WanMgr_DmlDhcpcGetInfo
     )
 {
     UNREFERENCED_PARAMETER(hContext);
-    ULONG                           index  = 0;
     ANSC_STATUS  rc;
-    dhcpv4c_ip_list_t address;
-    int i;
 
     if ( (!pInfo) || (ulInstanceNumber != 1) ){
         return ANSC_STATUS_FAILURE;
     }
 
     pInfo->Status = DML_DHCP_STATUS_Enabled;
-    dhcpv4c_get_ert_fsm_state((int*)&pInfo->DHCPStatus);
-    dhcpv4c_get_ert_ip_addr((unsigned int*)&pInfo->IPAddress.Value);
-    dhcpv4c_get_ert_mask((unsigned int*)&pInfo->SubnetMask.Value);
-    pInfo->NumIPRouters = 1;
-    dhcpv4c_get_ert_gw((unsigned int*)&pInfo->IPRouters[0].Value);
-    address.number = 0;
-    dhcpv4c_get_ert_dns_svrs(&address);
-    pInfo->NumDnsServers = address.number;
-    if (pInfo->NumDnsServers > DML_DHCP_MAX_ENTRIES)
-    {
-        CcspTraceError(("!!! Max DHCP Entry Overflow: %d",address.number));
-        pInfo->NumDnsServers = DML_DHCP_MAX_ENTRIES; // Fail safe
-    }
-    for(i=0; i< pInfo->NumDnsServers;i++)
-        pInfo->DNSServers[i].Value = address.addrs[i];
-    dhcpv4c_get_ert_remain_lease_time((unsigned int*)&pInfo->LeaseTimeRemaining);
-    dhcpv4c_get_ert_dhcp_svr((unsigned int*)&pInfo->DHCPServer);
 
+    DML_VIRTUAL_IFACE *p_VirtIf = WanMgr_GetActiveVirtIfData_locked();
+    if(p_VirtIf != NULL)
+    {
+        pInfo->IPAddress.Value     = inet_addr(p_VirtIf->IP.Ipv4Data.ip);
+        pInfo->SubnetMask.Value    = inet_addr(p_VirtIf->IP.Ipv4Data.mask);
+        pInfo->IPRouters[0].Value  = inet_addr(p_VirtIf->IP.Ipv4Data.gateway);
+        pInfo->DNSServers[0].Value = inet_addr(p_VirtIf->IP.Ipv4Data.dnsServer);
+        pInfo->DNSServers[1].Value = inet_addr(p_VirtIf->IP.Ipv4Data.dnsServer1);
+        pInfo->DHCPStatus          = (strcmp(p_VirtIf->IP.Ipv4Data.dhcpState, DHCP_STATE_UP) == 0) ? DML_DHCPC_STATUS_Bound : DML_DHCPC_STATUS_Init;
+        WanMgrDml_GetIfaceData_release(NULL);
+    }
+    pInfo->NumDnsServers = 2;
+    pInfo->NumIPRouters = 1;
     return ANSC_STATUS_SUCCESS;
 }
 


### PR DESCRIPTION
Reason for change: Remove sysevent and implemnt platform api
Test Procedure: No regression in DHCPv4 data model in UI
Risks: Low
Priority: P2

Change-Id: I4da4d800e6014a64182b07ed8293bd9e41cbc7d3