### PR TITLE
RDKB-55721: IPv4/v6 Address tr181 implementation

### DIFF
--- a/source/TR-181/middle_layer_src/wanmgr_rbus_handler_apis.c
+++ b/source/TR-181/middle_layer_src/wanmgr_rbus_handler_apis.c
@@ -89,12 +89,12 @@ rbusDataElement_t wanMgrIfacePublishElements[] = {
     {WANMGR_V1_INFACE_PHY_STATUS, RBUS_ELEMENT_TYPE_PROPERTY, {WanMgr_Interface_GetHandler, NULL, NULL, NULL, wanMgrDmlPublishEventHandler, NULL}},
     {WANMGR_V1_INFACE_WAN_STATUS, RBUS_ELEMENT_TYPE_PROPERTY, {WanMgr_Interface_GetHandler, NULL, NULL, NULL, wanMgrDmlPublishEventHandler, NULL}},
     {WANMGR_V1_INFACE_WAN_LINKSTATUS, RBUS_ELEMENT_TYPE_PROPERTY, {WanMgr_Interface_GetHandler, NULL, NULL, NULL, wanMgrDmlPublishEventHandler, NULL}},
-#endif /** WAN_MANAGER_UNIFICATION_ENABLED */
-    {WANMGR_INFACE_WAN_STATUS, RBUS_ELEMENT_TYPE_PROPERTY, {WanMgr_Interface_GetHandler, WanMgr_Interface_SetHandler, NULL, NULL, wanMgrDmlPublishEventHandler, NULL}},
-    {WANMGR_INFACE_WAN_LINKSTATUS, RBUS_ELEMENT_TYPE_PROPERTY, {WanMgr_Interface_GetHandler, WanMgr_Interface_SetHandler, NULL, NULL, wanMgrDmlPublishEventHandler, NULL}},
     {WANMGR_INFACE_IPv4_ADDRESS, RBUS_ELEMENT_TYPE_PROPERTY, {WanMgr_Interface_GetHandler, NULL, NULL, NULL, wanMgrDmlPublishEventHandler, NULL}},
     {WANMGR_INFACE_IPv6_ADDRESS, RBUS_ELEMENT_TYPE_PROPERTY, {WanMgr_Interface_GetHandler, NULL, NULL, NULL, wanMgrDmlPublishEventHandler, NULL}},
     {WANMGR_INFACE_IPv6_PREFIX, RBUS_ELEMENT_TYPE_PROPERTY, {WanMgr_Interface_GetHandler, NULL, NULL, NULL, wanMgrDmlPublishEventHandler, NULL}},
+#endif /** WAN_MANAGER_UNIFICATION_ENABLED */
+    {WANMGR_INFACE_WAN_STATUS, RBUS_ELEMENT_TYPE_PROPERTY, {WanMgr_Interface_GetHandler, WanMgr_Interface_SetHandler, NULL, NULL, wanMgrDmlPublishEventHandler, NULL}},
+    {WANMGR_INFACE_WAN_LINKSTATUS, RBUS_ELEMENT_TYPE_PROPERTY, {WanMgr_Interface_GetHandler, WanMgr_Interface_SetHandler, NULL, NULL, wanMgrDmlPublishEventHandler, NULL}},
 };
 
 RemoteDM_list RemoteDMs[] = {

--- a/source/TR-181/middle_layer_src/wanmgr_rbus_handler_apis.h
+++ b/source/TR-181/middle_layer_src/wanmgr_rbus_handler_apis.h
@@ -45,6 +45,9 @@
 #define WANMGR_INFACE_PHY_STATUS                      "Device.X_RDK_WanManager.Interface.{i}.BaseInterfaceStatus"
 #define WANMGR_INFACE_WAN_STATUS                      "Device.X_RDK_WanManager.Interface.{i}.VirtualInterface.{i}.Status"
 #define WANMGR_INFACE_WAN_LINKSTATUS                  "Device.X_RDK_WanManager.Interface.{i}.VirtualInterface.{i}.VlanStatus"
+#define WANMGR_INFACE_IPv4_ADDRESS                    "Device.X_RDK_WanManager.Interface.{i}.VirtualInterface.{i}.IP.IPv4Address"
+#define WANMGR_INFACE_IPv6_ADDRESS                    "Device.X_RDK_WanManager.Interface.{i}.VirtualInterface.{i}.IP.IPv6Address"
+#define WANMGR_INFACE_IPv6_PREFIX                     "Device.X_RDK_WanManager.Interface.{i}.VirtualInterface.{i}.IP.IPv6Prefix"
 #define WANMGR_INFACE_WAN_ENABLE                      "Device.X_RDK_WanManager.Interface.{i}.Selection.Enable"
 #define WANMGR_INFACE_ALIASNAME                       "Device.X_RDK_WanManager.Interface.{i}.Alias"
 
@@ -175,6 +178,7 @@ ANSC_STATUS WanMgr_IDM_Invoke(idm_invoke_method_Params_t *IDM_request);
 
 ANSC_STATUS WanMgr_Rbus_Init();
 ANSC_STATUS WanMgr_Rbus_Exit();
+ANSC_STATUS WanMgr_Rbus_EventPublishHandler(const char *dm_event, void *dm_value, rbusValueType_t valueType);
 ANSC_STATUS WanMgr_Rbus_String_EventPublish(char *dm_event, void *dm_value);
 ANSC_STATUS WanMgr_Rbus_String_EventPublish_OnValueChange(char *dm_event, void *prev_dm_value, void *dm_value);
 ANSC_STATUS WanMgr_Rbus_getUintParamValue(char * param, UINT * value);

--- a/source/WanManager/wanmgr_dhcpv4_apis.c
+++ b/source/WanManager/wanmgr_dhcpv4_apis.c
@@ -250,6 +250,13 @@ ANSC_STATUS wanmgr_handle_dhcpv4_event_data(DML_VIRTUAL_IFACE* pVirtIf)
         WanManager_UpdateInterfaceStatus(pVirtIf, WANMGR_IFACE_CONNECTION_DOWN);
     }
 
+    if(IPv4ConfigChanged == TRUE)
+    {
+        char param_name[256] = {0};
+        snprintf(param_name, sizeof(param_name), "Device.X_RDK_WanManager.Interface.%d.VirtualInterface.%d.IP.IPv4Address",  pVirtIf->baseIfIdx+1, pVirtIf->VirIfIdx+1);
+        WanMgr_Rbus_EventPublishHandler(param_name, pVirtIf->IP.Ipv4Data.ip, RBUS_STRING);
+    }
+
     if (pVirtIf->IP.pIpcIpv4Data != NULL )
     {
         //free memory

--- a/source/WanManager/wanmgr_dhcpv6_apis.c
+++ b/source/WanManager/wanmgr_dhcpv6_apis.c
@@ -1811,6 +1811,13 @@ ANSC_STATUS wanmgr_handle_dhcpv6_event_data(DML_VIRTUAL_IFACE * pVirtIf)
             CcspTraceInfo(("IPv6 configuration has been changed \n"));
             pVirtIf->IP.Ipv6Changed = TRUE;
             CcspTraceInfo(("%s %d - RestartConnectivityCheck triggered. \n", __FUNCTION__, __LINE__));
+
+            char param_name[256] = {0};
+            snprintf(param_name, sizeof(param_name), "Device.X_RDK_WanManager.Interface.%d.VirtualInterface.%d.IP.IPv6Address",  pVirtIf->baseIfIdx+1, pVirtIf->VirIfIdx+1);
+            WanMgr_Rbus_EventPublishHandler(param_name, Ipv6DataTemp.address,RBUS_STRING);
+            snprintf(param_name, sizeof(param_name), "Device.X_RDK_WanManager.Interface.%d.VirtualInterface.%d.IP.IPv6Prefix",  pVirtIf->baseIfIdx+1, pVirtIf->VirIfIdx+1);
+            WanMgr_Rbus_EventPublishHandler(param_name, Ipv6DataTemp.sitePrefix,RBUS_STRING);
+
             pVirtIf->IP.RestartConnectivityCheck = TRUE;
         }
         else

--- a/source/WanManager/wanmgr_interface_sm.c
+++ b/source/WanManager/wanmgr_interface_sm.c
@@ -2193,6 +2193,10 @@ static eWanState_t wan_transition_ipv4_down(WanMgr_IfaceSM_Controller_t* pWanIfa
 
     WanMgr_SendMsgTo_ConnectivityCheck(pWanIfaceCtrl, CONNECTION_MSG_IPV4 , FALSE);
 
+    char param_name[256] = {0};
+    snprintf(param_name, sizeof(param_name), "Device.X_RDK_WanManager.Interface.%d.VirtualInterface.%d.IP.IPv4Address",  p_VirtIf->baseIfIdx+1, p_VirtIf->VirIfIdx+1);
+    WanMgr_Rbus_EventPublishHandler(param_name, "",RBUS_STRING);
+
     Update_Interface_Status();
     sysevent_get(sysevent_fd, sysevent_token, SYSEVENT_IPV6_CONNECTION_STATE, buf, sizeof(buf));
 
@@ -2442,6 +2446,11 @@ static eWanState_t wan_transition_ipv6_down(WanMgr_IfaceSM_Controller_t* pWanIfa
         }
     }
 
+    char param_name[256] = {0};
+    snprintf(param_name, sizeof(param_name), "Device.X_RDK_WanManager.Interface.%d.VirtualInterface.%d.IP.IPv6Address",  p_VirtIf->baseIfIdx+1, p_VirtIf->VirIfIdx+1);
+    WanMgr_Rbus_EventPublishHandler(param_name, "", RBUS_STRING);
+    snprintf(param_name, sizeof(param_name), "Device.X_RDK_WanManager.Interface.%d.VirtualInterface.%d.IP.IPv6Prefix",  p_VirtIf->baseIfIdx+1, p_VirtIf->VirIfIdx+1);
+    WanMgr_Rbus_EventPublishHandler(param_name, "", RBUS_STRING);
     WanManager_UpdateInterfaceStatus (p_VirtIf, WANMGR_IFACE_CONNECTION_IPV6_DOWN);
 
     if(p_VirtIf->Status == WAN_IFACE_STATUS_UP)


### PR DESCRIPTION
Reason for change: Implementing below rbus TR181 entries Device.X_RDK_WanManager.Interface.{i}.VirtualInterface.{i}.IP.IPv4Address Device.X_RDK_WanManager.Interface.{i}.VirtualInterface.{i}.IP.IPv6Address

Test Procedure:
Updated in Jira.

Risks: none
Priority: P1