### PR TITLE
RDKB-54150:webconfig service should only be accessed after Wan UP

### DIFF
--- a/source/WanManager/wanmgr_main.c
+++ b/source/WanManager/wanmgr_main.c
@@ -59,7 +59,6 @@
 #include "wanmgr_ssp_global.h"
 #include "wanmgr_core.h"
 #include "wanmgr_data.h"
-#include "wanmgr_webconfig_apis.h"
 #include "stdlib.h"
 #include "ccsp_dm_api.h"
 
@@ -387,7 +386,6 @@ int main(int argc, char* argv[])
 
     waitUntilSystemReady();
 
-    WanMgrDmlWanWebConfigInit();
 #ifdef ENABLE_FEATURE_TELEMETRY2_0
     t2_init(COMPONENT_NAME_WANMANAGER);
 #endif


### PR DESCRIPTION
Reason for change:Web Configuration Registration from WanManager to get/set Blob should Start after first WAN Up,
                               Because Initial webconfig process is starting after first WAN Up.
Test Procedure:
1.)Test Web Config Registration.
Risks: Medium
Priority: P2
Signed-off-by: kulvendra singh <kulvendra.singh@sky.uk>