### PR TITLE
 RDKB-54270:Changing the zebra-restart event name when lanmanager distro enabled

### DIFF
--- a/source/WanManager/wanmgr_dhcp_legacy_apis.c
+++ b/source/WanManager/wanmgr_dhcp_legacy_apis.c
@@ -1058,8 +1058,11 @@ dhcpv6c_dbg_thrd(void * in)
                             CcspTraceWarning(("%s: Failure in executing command via v_secure_system. ret:[%d] \n",__FUNCTION__,ret));
                         }
 #else
-                       
+#ifdef LAN_MGR_SUPPORT
+                        v_secure_system("sysevent set dhcpv6_raserver-restart");
+#else
                         v_secure_system("sysevent set zebra-restart \n");
+#endif
 #endif
                         //CcspTraceWarning(("!run cmd1:%s", cmd));
 
@@ -1229,7 +1232,11 @@ dhcpv6c_dbg_thrd(void * in)
 #if defined(CISCO_CONFIG_DHCPV6_PREFIX_DELEGATION) && (defined(_CBR_PRODUCT_REQ_) || defined(_BCI_FEATURE_REQ))
 
 #else
+#ifdef LAN_MGR_SUPPORT
+        v_secure_system("sysevent set dhcpv6_raserver-restart");
+#else
         v_secure_system("sysevent set zebra-restart");
+#endif
 #endif
             }
 

--- a/source/WanManager/wanmgr_dhcpv6_apis.c
+++ b/source/WanManager/wanmgr_dhcpv6_apis.c
@@ -1985,7 +1985,11 @@ int setUpLanPrefixIPv6(DML_VIRTUAL_IFACE* pVirtIf)
 #ifndef _HUB4_PRODUCT_REQ_
         snprintf(cmdLine, sizeof(cmdLine), "sysevent set ipv6_prefix %s ",v6pref);
 #else
+#ifdef LAN_MGR_SUPPORT
+        snprintf(cmdLine, sizeof(cmdLine), "sysevent set dhcpv6_raserver-restart ");
+#else
         snprintf(cmdLine, sizeof(cmdLine), "sysevent set zebra-restart ");
+#endif
 #endif
         if (WanManager_DoSystemActionWithStatus(__FUNCTION__, cmdLine) != 0)
             CcspTraceError(("failed to run cmd: %s", cmdLine));

--- a/source/WanManager/wanmgr_sysevents.c
+++ b/source/WanManager/wanmgr_sysevents.c
@@ -727,7 +727,11 @@ static void *WanManagerSyseventHandler(void *args)
                         CcspTraceError(("%s %d - SetDataModelParameter failed on ipv6_enable request \n", __FUNCTION__, __LINE__ ));
                     }
                     free(datamodel_value);
+#ifdef LAN_MGR_SUPPORT
+                    v_secure_system("sysevent set dhcpv6_raserver-restart");
+#else
                     v_secure_system("sysevent set zebra-restart");
+#endif
                 }
             }
             else if ((strcmp(name, SYSEVENT_WAN_STATUS) == 0) && (strcmp(val, SYSEVENT_VALUE_STARTED) == 0))


### PR DESCRIPTION
Reason for change: Zebra-restart will be replaced with dhcpv6_raserver-restart

Test Procedure: 1. Lanmanger event should get triggered when
		   lanmanager distro is enabled
		2. ra.conf file gets created Risks: None

Signed-off-by: raghavendra.hegde2@comcast.com