### PR TITLE
IPV6 address changes are not triggering telemetry events

### DIFF
--- a/source/WanManager/wanmgr_interface_sm.c
+++ b/source/WanManager/wanmgr_interface_sm.c
@@ -1400,6 +1400,15 @@ static int wan_tearDownIPv6(WanMgr_IfaceSM_Controller_t * pWanIfaceCtrl)
     sysevent_set(sysevent_fd, sysevent_token, SYSEVENT_FIREWALL_RESTART, NULL, 0);
 #endif
 
+//RBUS_WAN_IP
+#if defined (RBUS_WAN_IP)
+#if defined (_HUB4_PRODUCT_REQ_) || defined (_SR213_PRODUCT_REQ_)
+    sysevent_set(sysevent_fd, sysevent_token, SYSEVENT_LAN_IPV6_ADDRESS, "::", 0);
+#else
+    sysevent_set(sysevent_fd, sysevent_token, SYSEVENT_IPV6_WAN_ADDRESS, "::", 0);
+#endif
+#endif
+
     sysevent_get(sysevent_fd, sysevent_token, SYSEVENT_WAN_STATUS, buf, sizeof(buf));
     if ((strcmp(buf, WAN_STATUS_STOPPED) != 0) && (p_VirtIf->IP.Ipv4Status == WAN_IFACE_IPV4_STATE_DOWN))
     {

--- a/source/WanManager/wanmgr_sysevents.h
+++ b/source/WanManager/wanmgr_sysevents.h
@@ -64,6 +64,10 @@
 #define SYSEVENT_IPV4_DS_CURRENT_RATE "ipv4_%s_ds_current_rate_0"
 #define SYSEVENT_FIELD_SERVICE_ROUTED_STATUS "routed-status"
 #define SYSEVENT_IPV4_MTU_SIZE "ipv4_%s_mtu"
+
+#define SYSEVENT_IPV6_WAN_ADDRESS "tr_erouter0_dhcpv6_client_v6addr"
+#define SYSEVENT_LAN_IPV6_ADDRESS "lan_ipaddr_v6"
+
 #define MESH_IFNAME        "br-home"
 #if defined (RDKB_EXTENDER_ENABLED)
 #define SYSEVENT_MESH_WAN_LINK_STATUS "mesh_wan_linkstatus"


### PR DESCRIPTION
Reason for change:
IPV6 address changes are not triggering telemetry events

Test Procedure:
Make a build and check whether IPV6 address changes triggering telemetry events.

Risks: None
Signed-off-by: kavya_chowdahallisuresh@comcast.com