### PR TITLE
RDKB-56195 : Control DNS health check using RFC in VISM

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -44,7 +44,10 @@ m4_ifdef([AM_SILENT_RULES],[AM_SILENT_RULES([yes])],
   [AM_DEFAULT_VERBOSITY=1
    AC_SUBST(AM_DEFAULT_VERBOSITY)])
 
-
+m4_define([GIT_VERSION],
+  m4_esyscmd_s([git describe --tags --always --dirty 2>/dev/null || echo "undefined"])
+)
+AC_SUBST([GIT_VERSION], [GIT_VERSION])
 
 
 dnl **********************************

--- a/source/TR-181/include/wanmgr_dml.h
+++ b/source/TR-181/include/wanmgr_dml.h
@@ -352,7 +352,7 @@ typedef struct _DML_WANIFACE_IP
     DML_WAN_IP_SOURCE           IPv6Source;
     BOOL                        ConnectivityCheckRunning;
     BOOL                        RestartConnectivityCheck;
-    BOOL                        WCC_TypeChanged; // Falg to notify change in ConnectivityCheckType
+    BOOL                        WCC_TypeChanged; // Flag to notify change in ConnectivityCheckType
     BOOL                        RefreshDHCP;
     BOOL                        RestartV6Client; //This is a workaround to restart dhcpv6 client for the platform where PAM configures IPv6. !FEATURE_RDKB_CONFIGURABLE_WAN_INTERFACE
     DML_WAN_IP_MODE             Mode;

--- a/source/TR-181/include/wanmgr_dml.h
+++ b/source/TR-181/include/wanmgr_dml.h
@@ -352,6 +352,7 @@ typedef struct _DML_WANIFACE_IP
     DML_WAN_IP_SOURCE           IPv6Source;
     BOOL                        ConnectivityCheckRunning;
     BOOL                        RestartConnectivityCheck;
+    BOOL                        WCC_TypeChanged; // Falg to notify change in ConnectivityCheckType
     BOOL                        RefreshDHCP;
     BOOL                        RestartV6Client; //This is a workaround to restart dhcpv6 client for the platform where PAM configures IPv6. !FEATURE_RDKB_CONFIGURABLE_WAN_INTERFACE
     DML_WAN_IP_MODE             Mode;

--- a/source/TR-181/middle_layer_src/wanmgr_dml_iface_v2_apis.c
+++ b/source/TR-181/middle_layer_src/wanmgr_dml_iface_v2_apis.c
@@ -1835,7 +1835,10 @@ BOOL WanVirtualIf_SetParamUlongValue(ANSC_HANDLE hInsContext, char* ParamName, U
 #endif
         if (strcmp(ParamName, "Timeout") == 0)
         {
-            p_VirtIf->VLAN.Timeout = uValue;
+            //p_VirtIf->VLAN.Timeout = uValue;
+            p_VirtIf->IP.ConnectivityCheckType = uValue;
+            p_VirtIf->IP.WCC_TypeChanged = TRUE;
+            CcspTraceInfo(("%s %d PARTHI ConnectivityCheckType changed to %s\n", __FUNCTION__, __LINE__, (p_VirtIf->IP.ConnectivityCheckType == WAN_CONNECTIVITY_TYPE_TAD) ? "WAN_CONNECTIVITY_TYPE_TAD":(p_VirtIf->IP.ConnectivityCheckType == WAN_CONNECTIVITY_TYPE_IHC)?"WAN_CONNECTIVITY_TYPE_IHC":"WAN_CONNECTIVITY_TYPE_NONE"));
             ret = TRUE;
         }
         WanMgr_VirtualIfaceData_release(p_VirtIf);

--- a/source/TR-181/middle_layer_src/wanmgr_dml_iface_v2_apis.c
+++ b/source/TR-181/middle_layer_src/wanmgr_dml_iface_v2_apis.c
@@ -1835,10 +1835,7 @@ BOOL WanVirtualIf_SetParamUlongValue(ANSC_HANDLE hInsContext, char* ParamName, U
 #endif
         if (strcmp(ParamName, "Timeout") == 0)
         {
-            //p_VirtIf->VLAN.Timeout = uValue;
-            p_VirtIf->IP.ConnectivityCheckType = uValue;
-            p_VirtIf->IP.WCC_TypeChanged = TRUE;
-            CcspTraceInfo(("%s %d PARTHI ConnectivityCheckType changed to %s\n", __FUNCTION__, __LINE__, (p_VirtIf->IP.ConnectivityCheckType == WAN_CONNECTIVITY_TYPE_TAD) ? "WAN_CONNECTIVITY_TYPE_TAD":(p_VirtIf->IP.ConnectivityCheckType == WAN_CONNECTIVITY_TYPE_IHC)?"WAN_CONNECTIVITY_TYPE_IHC":"WAN_CONNECTIVITY_TYPE_NONE"));
+            p_VirtIf->VLAN.Timeout = uValue;
             ret = TRUE;
         }
         WanMgr_VirtualIfaceData_release(p_VirtIf);

--- a/source/WanManager/Makefile.am
+++ b/source/WanManager/Makefile.am
@@ -28,5 +28,6 @@ wanmanager_CPPFLAGS = -I$(top_srcdir)/source/TR-181/middle_layer_src \
                       -I${PKG_CONFIG_SYSROOT_DIR}$(includedir)/rbus
 
 wanmanager_CFLAGS = -DFEATURE_SUPPORT_RDKLOG $(DBUS_CFLAGS) $(SYSTEMD_CFLAGS)
+wanmanager_CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
 wanmanager_SOURCES = wanmgr_webconfig_apis.c wanmgr_webconfig.c wanmgr_main.c  wanmgr_ssp_action.c wanmgr_ssp_messagebus_interface.c wanmgr_core.c wanmgr_controller.c wanmgr_data.c wanmgr_sysevents.c wanmgr_interface_sm.c wanmgr_utils.c wanmgr_net_utils.c wanmgr_dhcpv4_apis.c wanmgr_dhcpv6_apis.c wanmgr_ipc.c wanmgr_dhcpv4_internal.c wanmgr_dhcpv6_internal.c wanmgr_policy_autowan_impl.c wanmgr_policy_auto_impl.c dm_pack_datamodel.c wanmgr_wan_failover.c wanmgr_policy_parallel_scan_impl.c wanmgr_dhcp_legacy_apis.c
 wanmanager_LDADD = $(wanmanager_DEPENDENCIES) -lccsp_common -lrdkloggers $(DBUS_LIBS) $(SYSTEMD_LDFLAGS) -lhal_platform -lapi_dhcpv4c -lnanomsg -lwebconfig_framework -lmsgpackc -ldhcp_client_utils -lprivilege -lrbus -lsecure_wrapper

--- a/source/WanManager/wanmgr_interface_sm.c
+++ b/source/WanManager/wanmgr_interface_sm.c
@@ -110,6 +110,9 @@ static eWanState_t wan_transition_exit(WanMgr_IfaceSM_Controller_t* pWanIfaceCtr
 static ANSC_STATUS WanMgr_StartConnectivityCheck(WanMgr_IfaceSM_Controller_t* pWanIfaceCtrl);
 static ANSC_STATUS WanMgr_StopConnectivityCheck(WanMgr_IfaceSM_Controller_t* pWanIfaceCtrl);
 static ANSC_STATUS WanMgr_SendMsgTo_ConnectivityCheck(WanMgr_IfaceSM_Controller_t* pWanIfaceCtrl , CONNECTION_TYPE type, BOOL ConnStatus);
+#ifdef FEATURE_IPOE_HEALTH_CHECK
+static ANSC_STATUS WanManager_StopIHC(WanMgr_IfaceSM_Controller_t* pWanIfaceCtrl);
+#endif
 
 /***************************************************************************
  * @brief API used to check the incoming nameserver is valid
@@ -1509,7 +1512,7 @@ static ANSC_STATUS WanMgr_StartConnectivityCheck(WanMgr_IfaceSM_Controller_t* pW
     {
         CcspTraceInfo(("%s %d ConnectivityCheck Type is IHC \n", __FUNCTION__, __LINE__));
 #ifdef FEATURE_IPOE_HEALTH_CHECK
-        if ( p_VirtIf->Status == WAN_IFACE_STATUS_UP && pWanIfaceCtrl->IhcPid <= 0 )
+        if ( pVirtIf->Status == WAN_IFACE_STATUS_UP && pWanIfaceCtrl->IhcPid <= 0 )
         {
             // IHC enabled but not running, So Starting IHC
             UINT IhcPid = 0;

--- a/source/WanManager/wanmgr_interface_sm.c
+++ b/source/WanManager/wanmgr_interface_sm.c
@@ -447,6 +447,30 @@ static void WanMgr_MonitorDhcpApps (WanMgr_IfaceSM_Controller_t* pWanIfaceCtrl)
 #endif
     }
 
+    /* Handling Runtime IP.ConnectivityCheckType change */
+    if(p_VirtIf->IP.WCC_TypeChanged  == TRUE)
+    {
+        if(p_VirtIf->IP.ConnectivityCheckRunning == TRUE)
+        {
+            /* If IP.WCC_TypeChanged is set, we have lost the previous configuration of  ConnectivityCheckType.
+             * Blindly try to stop the Connectivity check services if running.
+             */
+#ifdef FEATURE_IPOE_HEALTH_CHECK
+            if(pWanIfaceCtrl->IhcPid > 0)
+            {
+                WanManager_StopIHC(pWanIfaceCtrl);        
+            }
+            else
+#endif
+            {
+                WanMgr_Configure_TAD_WCC( p_VirtIf,  WCC_STOP);        
+            }
+            p_VirtIf->IP.ConnectivityCheckRunning = FALSE;
+        }
+        WanMgr_StartConnectivityCheck(pWanIfaceCtrl); 
+        p_VirtIf->IP.WCC_TypeChanged  = FALSE; //Reset the flag
+    }
+
 #ifdef FEATURE_IPOE_HEALTH_CHECK
     if(p_VirtIf->IP.ConnectivityCheckType == WAN_CONNECTIVITY_TYPE_IHC &&
        p_VirtIf->IP.ConnectivityCheckRunning == TRUE &&
@@ -1189,6 +1213,7 @@ static int wan_setUpIPv4(WanMgr_IfaceSM_Controller_t * pWanIfaceCtrl)
 #endif
     /* Firewall restart. */
     sysevent_set(sysevent_fd, sysevent_token, SYSEVENT_FIREWALL_RESTART, NULL, 0);
+    WanMgr_StartConnectivityCheck(pWanIfaceCtrl);
     return ret;
 }
 
@@ -1343,6 +1368,7 @@ static int wan_setUpIPv6(WanMgr_IfaceSM_Controller_t * pWanIfaceCtrl)
 #endif
     }
   
+    WanMgr_StartConnectivityCheck(pWanIfaceCtrl);
     return ret;
 }
 
@@ -1477,12 +1503,13 @@ static ANSC_STATUS WanMgr_StartConnectivityCheck(WanMgr_IfaceSM_Controller_t* pW
     {
         CcspTraceInfo(("%s %d ConnectivityCheck Type is TAD \n", __FUNCTION__, __LINE__));
         WanMgr_Configure_TAD_WCC( pVirtIf, (pVirtIf->IP.ConnectivityCheckRunning && pVirtIf->IP.RestartConnectivityCheck) ? WCC_RESTART : WCC_START);
+        pVirtIf->IP.ConnectivityCheckRunning = TRUE;    
     }
     else if(pVirtIf->IP.ConnectivityCheckType == WAN_CONNECTIVITY_TYPE_IHC)
     {
         CcspTraceInfo(("%s %d ConnectivityCheck Type is IHC \n", __FUNCTION__, __LINE__));
 #ifdef FEATURE_IPOE_HEALTH_CHECK
-        if ( pWanIfaceCtrl->IhcPid <= 0 )
+        if ( p_VirtIf->Status == WAN_IFACE_STATUS_UP && pWanIfaceCtrl->IhcPid <= 0 )
         {
             // IHC enabled but not running, So Starting IHC
             UINT IhcPid = 0;
@@ -1497,13 +1524,13 @@ static ANSC_STATUS WanMgr_StartConnectivityCheck(WanMgr_IfaceSM_Controller_t* pW
             {
                 CcspTraceError(("%s %d - Failed to start IPoE Health Check for interface %s \n", __FUNCTION__, __LINE__, pVirtIf->Name));
             }
+            pVirtIf->IP.ConnectivityCheckRunning = TRUE;    
         }
 #endif
     }else
     {
         CcspTraceInfo(("[%s:%d] ConnectivityCheck not configured.\n", __FUNCTION__, __LINE__));
     }
-    pVirtIf->IP.ConnectivityCheckRunning = TRUE;    
     
     return ANSC_STATUS_SUCCESS;
 }
@@ -2088,7 +2115,6 @@ static eWanState_t wan_transition_ipv4_up(WanMgr_IfaceSM_Controller_t* pWanIface
         CcspTraceError(("%s %d - Failed to configure IPv4 successfully \n", __FUNCTION__, __LINE__));
     }
 
-    WanMgr_StartConnectivityCheck(pWanIfaceCtrl);
     WanMgr_SendMsgTo_ConnectivityCheck(pWanIfaceCtrl, CONNECTION_MSG_IPV4 , TRUE);
 
     /* Force reset ipv4 state global flag. */
@@ -2351,7 +2377,6 @@ static eWanState_t wan_transition_ipv6_up(WanMgr_IfaceSM_Controller_t* pWanIface
         CcspTraceError(("%s %d - Failed to configure IPv6 successfully \n", __FUNCTION__, __LINE__));
     }
 
-    WanMgr_StartConnectivityCheck(pWanIfaceCtrl);
     WanMgr_SendMsgTo_ConnectivityCheck(pWanIfaceCtrl, CONNECTION_MSG_IPV6 , TRUE);
 
     Update_Interface_Status();
@@ -2798,11 +2823,7 @@ static eWanState_t wan_transition_standby(WanMgr_IfaceSM_Controller_t* pWanIface
         WanMgr_Publish_WanStatus(pWanIfaceCtrl->interfaceIdx, pWanIfaceCtrl->VirIfIdx);
     }
 
-    //Start ConnectivityCheck while receiving Ip except IPOE health check case
-    if(p_VirtIf->IP.ConnectivityCheckType != WAN_CONNECTIVITY_TYPE_IHC)
-    {
-        WanMgr_StartConnectivityCheck(pWanIfaceCtrl);
-    }
+    WanMgr_StartConnectivityCheck(pWanIfaceCtrl);
 
     Update_Interface_Status();
     DmlSetVLANInUseToPSMDB(p_VirtIf);

--- a/source/WanManager/wanmgr_main.c
+++ b/source/WanManager/wanmgr_main.c
@@ -313,6 +313,7 @@ int main(int argc, char* argv[])
     pComponentName          = COMPONENT_NAME_WANMANAGER;
 
     rdk_logger_init(DEBUG_INI_NAME);
+    CcspTraceInfo(("Version : %s \n",GIT_VERSION ));
 
     //DATA INIT
     WanMgr_Data_Init();


### PR DESCRIPTION
Reason for change: Implementaion of Wan health check control from a RFC

Test Procedure:
Updated in Jira.

Risks: none
Priority: P1