### PR TITLE
RDKB-53816 : [Revert] - Remove EnableIPoEHealthCheck DML from WanManager

### DIFF
--- a/config/RdkWanManager.xml
+++ b/config/RdkWanManager.xml
@@ -228,6 +228,12 @@
                                     <writable>true</writable>
                                 </parameter>
                                 <parameter>
+                                    <name>EnableIPoEHealthCheck</name>
+                                    <type>boolean</type>
+                                    <syntax>bool</syntax>
+                                    <writable>true</writable>
+                                </parameter>
+                                <parameter>
                                     <name>EnableDHCP</name>
                                     <type>boolean</type>
                                     <syntax>bool</syntax>

--- a/config/RdkWanManager_v2.xml
+++ b/config/RdkWanManager_v2.xml
@@ -400,6 +400,12 @@
                                     <syntax>bool</syntax>
                                     <writable>true</writable>
                                 </parameter>
+                                <parameter>
+                                    <name>EnableIPoEHealthCheck</name>
+                                    <type>boolean</type>
+                                    <syntax>bool</syntax>
+                                    <writable>true</writable>
+                                </parameter>
 <?ifndef RBUS_BUILD_FLAG_ENABLE?>
                                 <parameter>
                                     <name>VlanStatus</name>

--- a/source/TR-181/middle_layer_src/wanmgr_dml_iface_apis.c
+++ b/source/TR-181/middle_layer_src/wanmgr_dml_iface_apis.c
@@ -962,6 +962,11 @@ BOOL WanIfCfg_GetParamBoolValue(ANSC_HANDLE hInsContext, char* ParamName, BOOL* 
                 *pBool = pWanDmlIface->VirtIfList->EnableDSLite;
                 ret = TRUE;
             }
+            if (strcmp(ParamName, "EnableIPoEHealthCheck") == 0)
+            {
+                *pBool = pWanDmlIface->VirtIfList->EnableIPoE;
+                ret = TRUE;
+            }
             if (strcmp(ParamName, "EnableMAPT") == 0)
             {
                 *pBool = pWanDmlIface->VirtIfList->EnableMAPT;
@@ -1037,6 +1042,11 @@ BOOL WanIfCfg_SetParamBoolValue(ANSC_HANDLE hInsContext, char* ParamName, BOOL b
             if (strcmp(ParamName, "EnableDSLite") == 0)
             {
                 pWanDmlIface->VirtIfList->EnableDSLite = bValue;
+                ret = TRUE;
+            }
+            if (strcmp(ParamName, "EnableIPoEHealthCheck") == 0)
+            {
+                pWanDmlIface->VirtIfList->EnableIPoE = bValue;
                 ret = TRUE;
             }
             if (strcmp(ParamName, "EnableMAPT") == 0)

--- a/source/TR-181/middle_layer_src/wanmgr_dml_iface_v2_apis.c
+++ b/source/TR-181/middle_layer_src/wanmgr_dml_iface_v2_apis.c
@@ -1508,6 +1508,11 @@ BOOL WanVirtualIf_GetParamBoolValue(ANSC_HANDLE hInsContext, char* ParamName, BO
             *pBool = p_VirtIf->EnableDSLite;
             ret = TRUE;
         }
+        if (strcmp(ParamName, "EnableIPoEHealthCheck") == 0)
+        {
+            *pBool = p_VirtIf->EnableIPoE;
+            ret = TRUE;
+        }
         if (strcmp(ParamName, "EnableMAPT") == 0)
         {
             *pBool = p_VirtIf->EnableMAPT;
@@ -1577,6 +1582,11 @@ BOOL WanVirtualIf_SetParamBoolValue(ANSC_HANDLE hInsContext, char* ParamName, BO
         if (strcmp(ParamName, "EnableDSLite") == 0)
         {
             p_VirtIf->EnableDSLite = bValue;
+            ret = TRUE;
+        }
+        if (strcmp(ParamName, "EnableIPoEHealthCheck") == 0)
+        {
+            p_VirtIf->EnableIPoE = bValue;
             ret = TRUE;
         }
         if (strcmp(ParamName, "EnableMAPT") == 0)


### PR DESCRIPTION
Reason for change: Removing EnableIPoEHealthCheck DML Test Procedure:
Updated in Jira.
Risks: none
Priority: P1
Signed-off-by: kulvendra singh <kulvendra.singh@sky.uk>