### PR TITLE
RDKB-56235: The IPv6 Address DM showing null after IPv6 Renew

### DIFF
--- a/source/TR-181/middle_layer_src/wanmgr_rbus_handler_apis.c
+++ b/source/TR-181/middle_layer_src/wanmgr_rbus_handler_apis.c
@@ -1659,6 +1659,30 @@ static void CPEInterface_AsyncMethodHandler(
                     strncpy( pWanIfaceData->AliasName, AliasName,sizeof(pWanIfaceData->AliasName)-1 );
                     //Set Alias name of Virtual interface
                     strncpy( pWanIfaceData->VirtIfList->Alias, AliasName,sizeof(pWanIfaceData->VirtIfList->Alias)-1 );
+                    //Register the interface again if Alias changed
+                    int rc = -1;
+                    rc = rbusTable_registerRow(rbusHandle, WANMGR_INFACE_TABLE, (cpeInterfaceIndex+1), AliasName);
+                    if(rc != RBUS_ERROR_SUCCESS)
+                    {
+                        CcspTraceError(("%s %d - Iterface(%d) Table (%s) Registartion failed \n", 
+                                    __FUNCTION__, __LINE__, (cpeInterfaceIndex+1), WANMGR_INFACE_TABLE));
+                    }
+#if defined(WAN_MANAGER_UNIFICATION_ENABLED)
+                    char tmpVIfTableName[256] = {0};
+                    for(int VirId=0; VirId< pWanDmlIfaceData->data.NoOfVirtIfs; VirId++)
+                    {
+                        snprintf(tmpVIfTableName, sizeof(tmpVIfTableName), WANMGR_VIRTUAL_INFACE_TABLE_ALIAS, AliasName);
+                        rc = rbusTable_registerRow(rbusHandle, tmpVIfTableName, (VirId+1), AliasName); //TODO: NEW_DESIGN get Alias name for virtual table
+                        if(rc != RBUS_ERROR_SUCCESS)
+                        {
+                            CcspTraceError(("%s %d - VirtualInterface(%d) Table (%s) Registartion failed, Error=%d \n", __FUNCTION__, __LINE__, (VirId+1), tmpVIfTableName, rc));
+                        }
+                        else
+                        {
+                            CcspTraceInfo(("%s %d - VirtualInterface(%d) Table (%s) Registartion Successfully, AliasName(%s)\n", __FUNCTION__, __LINE__, (VirId+1), tmpVIfTableName, AliasName));
+                        }
+                    }
+#endif
                 }
                 else if( WANMGR_PHY_STATUS_CHECK )
                 {

--- a/source/TR-181/middle_layer_src/wanmgr_rbus_handler_apis.h
+++ b/source/TR-181/middle_layer_src/wanmgr_rbus_handler_apis.h
@@ -42,6 +42,7 @@
 #define WANMGR_INFACE_TABLE                           "Device.X_RDK_WanManager.Interface"
 #define WANMGR_VIRTUAL_INFACE                         "Device.X_RDK_WanManager.Interface.{i}.VirtualInterface.{i}."
 #define WANMGR_VIRTUAL_INFACE_TABLE                   "Device.X_RDK_WanManager.Interface.%d.VirtualInterface"
+#define WANMGR_VIRTUAL_INFACE_TABLE_ALIAS             "Device.X_RDK_WanManager.Interface.\[%s\].VirtualInterface"
 #define WANMGR_INFACE_PHY_STATUS                      "Device.X_RDK_WanManager.Interface.{i}.BaseInterfaceStatus"
 #define WANMGR_INFACE_WAN_STATUS                      "Device.X_RDK_WanManager.Interface.{i}.VirtualInterface.{i}.Status"
 #define WANMGR_INFACE_WAN_LINKSTATUS                  "Device.X_RDK_WanManager.Interface.{i}.VirtualInterface.{i}.VlanStatus"

--- a/source/WanManager/wanmgr_dhcpv6_apis.c
+++ b/source/WanManager/wanmgr_dhcpv6_apis.c
@@ -1753,11 +1753,11 @@ ANSC_STATUS wanmgr_handle_dhcpv6_event_data(DML_VIRTUAL_IFACE * pVirtIf)
     /* Even when dhcp6c is not used to get the WAN interface IP address,
      *  * use this message as a trigger to check the WAN interface IP.
      *   * Maybe we've been assigned an address by SLAAC.*/
-    char guAddrPrefix[IP_ADDR_LENGTH] = {0};
+    char guAddr[IP_ADDR_LENGTH] = {0};
 
     if (!pNewIpcMsg->addrAssigned)
     {
-        char guAddr[IP_ADDR_LENGTH] = {0};
+        char guAddrPrefix[IP_ADDR_LENGTH] = {0};
         uint32_t prefixLen = 0;
         ANSC_STATUS r2;
 
@@ -1840,9 +1840,9 @@ ANSC_STATUS wanmgr_handle_dhcpv6_event_data(DML_VIRTUAL_IFACE * pVirtIf)
         pVirtIf->IP.Ipv6Status = WAN_IFACE_IPV6_STATE_UP;
 #if defined(FEATURE_RDKB_CONFIGURABLE_WAN_INTERFACE) || (defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_))  //TODO: V6 handled in PAM
         //If only Ipv6 prefix is renewed, IPv6 address is not shared in the lease details. Use the detected Ipv6 address.
-        if(strlen(guAddrPrefix) > 0 && strlen(pVirtIf->IP.Ipv6Data.address) <= 0) 
+        if(strlen(guAddr) > 0 && strlen(pVirtIf->IP.Ipv6Data.address) <= 0) 
         {
-            strncpy(pVirtIf->IP.Ipv6Data.address,guAddrPrefix, sizeof(pVirtIf->IP.Ipv6Data.address));
+            strncpy(pVirtIf->IP.Ipv6Data.address, guAddr, sizeof(pVirtIf->IP.Ipv6Data.address));
         }
 #endif
     }

--- a/source/WanManager/wanmgr_dhcpv6_apis.c
+++ b/source/WanManager/wanmgr_dhcpv6_apis.c
@@ -1753,10 +1753,11 @@ ANSC_STATUS wanmgr_handle_dhcpv6_event_data(DML_VIRTUAL_IFACE * pVirtIf)
     /* Even when dhcp6c is not used to get the WAN interface IP address,
      *  * use this message as a trigger to check the WAN interface IP.
      *   * Maybe we've been assigned an address by SLAAC.*/
+    char guAddrPrefix[IP_ADDR_LENGTH] = {0};
+
     if (!pNewIpcMsg->addrAssigned)
     {
         char guAddr[IP_ADDR_LENGTH] = {0};
-        char guAddrPrefix[IP_ADDR_LENGTH] = {0};
         uint32_t prefixLen = 0;
         ANSC_STATUS r2;
 
@@ -1837,6 +1838,13 @@ ANSC_STATUS wanmgr_handle_dhcpv6_event_data(DML_VIRTUAL_IFACE * pVirtIf)
         // update current IPv6 Data
         memcpy(&(pVirtIf->IP.Ipv6Data), &(Ipv6DataTemp), sizeof(WANMGR_IPV6_DATA));
         pVirtIf->IP.Ipv6Status = WAN_IFACE_IPV6_STATE_UP;
+#if defined(FEATURE_RDKB_CONFIGURABLE_WAN_INTERFACE) || (defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_))  //TODO: V6 handled in PAM
+        //If only Ipv6 prefix is renewed, IPv6 address is not shared in the lease details. Use the detetcted Ipv6 address.
+        if(strlen(guAddrPrefix) > 0 && strlen(pVirtIf->IP.Ipv6Data.address) <= 0) 
+        {
+            strncpy(pVirtIf->IP.Ipv6Data.address,guAddrPrefix, sizeof(pVirtIf->IP.Ipv6Data.address));
+        }
+#endif
     }
 
 #ifdef FEATURE_MAPT

--- a/source/WanManager/wanmgr_dhcpv6_apis.c
+++ b/source/WanManager/wanmgr_dhcpv6_apis.c
@@ -1839,7 +1839,7 @@ ANSC_STATUS wanmgr_handle_dhcpv6_event_data(DML_VIRTUAL_IFACE * pVirtIf)
         memcpy(&(pVirtIf->IP.Ipv6Data), &(Ipv6DataTemp), sizeof(WANMGR_IPV6_DATA));
         pVirtIf->IP.Ipv6Status = WAN_IFACE_IPV6_STATE_UP;
 #if defined(FEATURE_RDKB_CONFIGURABLE_WAN_INTERFACE) || (defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_))  //TODO: V6 handled in PAM
-        //If only Ipv6 prefix is renewed, IPv6 address is not shared in the lease details. Use the detetcted Ipv6 address.
+        //If only Ipv6 prefix is renewed, IPv6 address is not shared in the lease details. Use the detected Ipv6 address.
         if(strlen(guAddrPrefix) > 0 && strlen(pVirtIf->IP.Ipv6Data.address) <= 0) 
         {
             strncpy(pVirtIf->IP.Ipv6Data.address,guAddrPrefix, sizeof(pVirtIf->IP.Ipv6Data.address));

--- a/source/WanManager/wanmgr_interface_sm.c
+++ b/source/WanManager/wanmgr_interface_sm.c
@@ -2024,6 +2024,13 @@ static eWanState_t wan_transition_wan_validated(WanMgr_IfaceSM_Controller_t* pWa
         }
     }
 
+    if(pInterface->IfaceType == REMOTE_IFACE)
+    {
+        /* Mesh ULA ipv6 address is statically assigned for remote interface. copying to WanManager struct for tr181 DML */
+        CcspTraceInfo(("%s %d - Interface '%s' - Assigning Static ULA Ipv6 Address\n", __FUNCTION__, __LINE__, pInterface->Name));
+        sysevent_get(sysevent_fd, sysevent_token, "MeshRemoteWANInterface_UlaAddr", p_VirtIf->IP.Ipv6Data.address, sizeof(p_VirtIf->IP.Ipv6Data.address));
+    }
+
     return WAN_STATE_OBTAINING_IP_ADDRESSES;
 }
 

--- a/source/WanManager/wanmgr_interface_sm.c
+++ b/source/WanManager/wanmgr_interface_sm.c
@@ -2029,6 +2029,9 @@ static eWanState_t wan_transition_wan_validated(WanMgr_IfaceSM_Controller_t* pWa
         /* Mesh ULA ipv6 address is statically assigned for remote interface. copying to WanManager struct for tr181 DML */
         CcspTraceInfo(("%s %d - Interface '%s' - Assigning Static ULA Ipv6 Address\n", __FUNCTION__, __LINE__, pInterface->Name));
         sysevent_get(sysevent_fd, sysevent_token, "MeshRemoteWANInterface_UlaAddr", p_VirtIf->IP.Ipv6Data.address, sizeof(p_VirtIf->IP.Ipv6Data.address));
+        char *backslashPosition = strchr(p_VirtIf->IP.Ipv6Data.address, '/');  // Find the first occurrence of '/'. 
+        if (backslashPosition != NULL) 
+            *backslashPosition = '\0';  // Replace the backslash with a null character
     }
 
     return WAN_STATE_OBTAINING_IP_ADDRESSES;


### PR DESCRIPTION
Reason for change: Using detectedIpv6 Addr if ipv6 address(IANA) is not shared when IPv6 prefix is renewed.

Test Procedure:
Updated in Jira.

Risks: none
Priority: P1