### PR TITLE
Revert "RDKB-54150:webconfig service should only be accessed after Wan UP"

### DIFF
--- a/source/TR-181/middle_layer_src/wanmgr_rdkbus_apis.c
+++ b/source/TR-181/middle_layer_src/wanmgr_rdkbus_apis.c
@@ -41,8 +41,7 @@
 #ifdef RBUS_BUILD_FLAG_ENABLE
 #include "wanmgr_rbus_handler_apis.h"
 #endif //RBUS_BUILD_FLAG_ENABLE
-#include "wanmgr_webconfig_apis.h"
-
+//
 #define PSM_ENABLE_STRING_TRUE  "TRUE"
 #define PSM_ENABLE_STRING_FALSE  "FALSE"
 #define PPP_LINKTYPE_PPPOA "PPPoA"
@@ -1749,8 +1748,6 @@ ANSC_STATUS Update_Interface_Status()
     bool    publishCurrentStandbyInf = FALSE;
 #endif
     int uiLoopCount;
-    /*should allow WebConfig Handler Registartion Once.*/
-    static bool RegisterWebConfigOnce = false;
 
     WanMgr_Config_Data_t*   pWanConfigData = WanMgr_GetConfigData_locked();
     if (pWanConfigData != NULL)
@@ -1818,22 +1815,6 @@ ANSC_STATUS Update_Interface_Status()
                     /*In Modem/Extender Mode, CurrentActiveInterface should be always Mesh Interface Name*/
                     strncpy(newIface->CurrentActive, MESH_IFNAME, sizeof(MESH_IFNAME));
                 }
-                /*should allow WebConfig API Handler Registartion Once */
-		if (RegisterWebConfigOnce == false)
-                {
-                    if(((pWanIfaceData->IfaceType == REMOTE_IFACE &&
-                         p_VirtIf->Status == WAN_IFACE_STATUS_UP &&
-                         p_VirtIf->RemoteStatus == WAN_IFACE_STATUS_UP) ||
-                        (pWanIfaceData->IfaceType == LOCAL_IFACE &&
-                        p_VirtIf->Status == WAN_IFACE_STATUS_UP)) )
-                    {
-                        if (WanMgrDmlWanWebConfigInit() == ANSC_STATUS_SUCCESS)
-                        {
-                            RegisterWebConfigOnce = true;
-                        }
-                    }
-                }
-
                 /* Sort the link list based on priority */
                 SortedInsert(&head, newIface);
             }

--- a/source/WanManager/wanmgr_main.c
+++ b/source/WanManager/wanmgr_main.c
@@ -59,6 +59,7 @@
 #include "wanmgr_ssp_global.h"
 #include "wanmgr_core.h"
 #include "wanmgr_data.h"
+#include "wanmgr_webconfig_apis.h"
 #include "stdlib.h"
 #include "ccsp_dm_api.h"
 
@@ -387,6 +388,7 @@ int main(int argc, char* argv[])
 
     waitUntilSystemReady();
 
+    WanMgrDmlWanWebConfigInit();
 #ifdef ENABLE_FEATURE_TELEMETRY2_0
     t2_init(COMPONENT_NAME_WANMANAGER);
 #endif


### PR DESCRIPTION
Reverts rdkcentral/RdkWanManager#34

Reverting due to Gtest failure reported in RDKB-56270