### PR TITLE
RDKB-56030 :XDNS is not working for WAN Disconnect/Reconnect and Line Migration

### DIFF
--- a/source/WanManager/wanmgr_interface_sm.c
+++ b/source/WanManager/wanmgr_interface_sm.c
@@ -883,7 +883,7 @@ int wan_updateDNS(WanMgr_IfaceSM_Controller_t* pWanIfaceCtrl, BOOL addIPv4, BOOL
     }
     char XDSEnableString[16] = { 0 };
     if (valid_dns == TRUE && \
-       (syscfg_get(NULL, SYSCFG_XDNS_ENABLE, XDSEnableString, sizeof(XDSEnableString)) == CMSRET_SUCCESS) && \
+       (syscfg_get(NULL, SYSCFG_XDNS_ENABLE, XDSEnableString, sizeof(XDSEnableString)) == 0 ) && \
        ( XDSEnableString[0] == '1' ) )
     {
         FILE *fp1 = NULL;
@@ -894,24 +894,24 @@ int wan_updateDNS(WanMgr_IfaceSM_Controller_t* pWanIfaceCtrl, BOOL addIPv4, BOOL
         }
         else
         {
-            charbuf[BUFLEN_256]={0};
+            char buf[BUFLEN_256]={0};
             //GetXDNSconffileentries
             while(NULL!=fgets(buf,sizeof(buf),fp1))
-        {
-            buf[strcspn(buf,"\n")]=0;//removenewlinechar
-        if(!strlen(buf))
-        {
-            //Clearbuffer
-            memset(buf,0,sizeof(buf));
-            continue;
+            {
+                buf[strcspn(buf,"\n")]=0;//removenewlinechar
+                if(!strlen(buf))
+                {
+                    //Clearbuffer
+                    memset(buf,0,sizeof(buf));
+                    continue;
+                }
+                fprintf(fp,"%s\n",buf);
+                //Clearbuffer
+                memset(buf,0,sizeof(buf));
+            }  
+            fclose(fp1);
+            fp1 = NULL;
         }
-        fprintf(fp,"%s\n",buf);
-        //Clearbuffer
-        memset(buf,0,sizeof(buf));
-        }
-        fclose(fp1);
-        fp1 = NULL;
-     }
     }
     else
     {


### PR DESCRIPTION
Reason for change:  The XDNS configs were not updated to resolv.conf during WAN reconnect.

Risks: Medium
Priority: P1
Signed-off-by: Kanchana karthika <kanchana.karthika@sky.uk>