### PR TITLE
RDKB-51706 : [MAP-T-HUB6] Index update issue in DM -Device.DHCPv6.Client.1.Interface

### DIFF
--- a/source/TR-181/middle_layer_src/wanmgr_dml_dhcpv6.c
+++ b/source/TR-181/middle_layer_src/wanmgr_dml_dhcpv6.c
@@ -852,7 +852,13 @@ Client3_GetParamStringValue
     }
     else if (strcmp(ParamName, "Interface") == 0)
     {
+#if defined(FEATURE_RDKB_CONFIGURABLE_WAN_INTERFACE)
+        char client_ifname[10] = {0};
+        sysevent_get(sysevent_fd, sysevent_token, SYSEVENT_CURRENT_WAN_IFNAME, client_ifname, sizeof(client_ifname));
+        DmlGetInstanceByKeywordFromPandM(client_ifname, &instanceNumber);
+#else	    
         DmlGetInstanceByKeywordFromPandM(pDhcpc->Cfg.Interface, &instanceNumber);
+#endif	
         snprintf(interface, DATAMODEL_PARAM_LENGTH, PAM_IF_TABLE_OBJECT, instanceNumber);
         if ( interface[0] != '\0' )
         {

--- a/source/WanManager/wanmgr_interface_sm.c
+++ b/source/WanManager/wanmgr_interface_sm.c
@@ -419,7 +419,6 @@ static void WanMgr_MonitorDhcpApps (WanMgr_IfaceSM_Controller_t* pWanIfaceCtrl)
     {
         // let the caller state handle RefreshDHCP=TRUE scenario
         CcspTraceError(("%s %d: IP Mode change detected, handle RefreshDHCP & later monitor DHCP apps\n", __FUNCTION__, __LINE__));
-	p_VirtIf->IP.RefreshDHCP = FALSE ;
         return;
     }
 

--- a/source/WanManager/wanmgr_interface_sm.c
+++ b/source/WanManager/wanmgr_interface_sm.c
@@ -419,6 +419,7 @@ static void WanMgr_MonitorDhcpApps (WanMgr_IfaceSM_Controller_t* pWanIfaceCtrl)
     {
         // let the caller state handle RefreshDHCP=TRUE scenario
         CcspTraceError(("%s %d: IP Mode change detected, handle RefreshDHCP & later monitor DHCP apps\n", __FUNCTION__, __LINE__));
+	p_VirtIf->IP.RefreshDHCP = FALSE ;
         return;
     }
 


### PR DESCRIPTION
Reason for change: Wrong interface was passed in case of VDSL, modified to send current wan interface.

Test Procedure:
Updated in Jira.

Risks: none
Priority: P2