### PR TITLE
RDKB-55171:Excessive logging in WANManager on changing the IP Mode

### DIFF
--- a/source/WanManager/wanmgr_interface_sm.c
+++ b/source/WanManager/wanmgr_interface_sm.c
@@ -419,6 +419,7 @@ static void WanMgr_MonitorDhcpApps (WanMgr_IfaceSM_Controller_t* pWanIfaceCtrl)
     {
         // let the caller state handle RefreshDHCP=TRUE scenario
         CcspTraceError(("%s %d: IP Mode change detected, handle RefreshDHCP & later monitor DHCP apps\n", __FUNCTION__, __LINE__));
+	p_VirtIf->IP.RefreshDHCP = FALSE;
         return;
     }
 


### PR DESCRIPTION
Reason for change: RefreshDHCP Flag was not set to false which led to flooding of logs.

Test Procedure:
Updated in Jira.

Risks: none
Priority: P2