### PR TITLE
TCXB7-6810:COX -TXB7 - MAPT is not Working after WA cable disconnect/…

### DIFF
--- a/source/WanManager/wanmgr_interface_sm.c
+++ b/source/WanManager/wanmgr_interface_sm.c
@@ -1455,7 +1455,7 @@ static int wan_tearDownIPv6(WanMgr_IfaceSM_Controller_t * pWanIfaceCtrl)
 #endif
 
     sysevent_get(sysevent_fd, sysevent_token, SYSEVENT_WAN_STATUS, buf, sizeof(buf));
-    if ((strcmp(buf, WAN_STATUS_STOPPED) != 0) && (p_VirtIf->IP.Ipv4Status == WAN_IFACE_IPV4_STATE_DOWN))
+    if ((strcmp(buf, WAN_STATUS_STOPPED) != 0) && ((p_VirtIf->IP.Ipv4Status == WAN_IFACE_IPV4_STATE_DOWN) && (p_VirtIf->MAP.MaptStatus == WAN_IFACE_MAPT_STATE_DOWN)))
     {
         sysevent_set(sysevent_fd, sysevent_token, SYSEVENT_WAN_STATUS, WAN_STATUS_STOPPED, 0);
         sysevent_set(sysevent_fd, sysevent_token, SYSEVENT_WAN_SERVICE_STATUS, WAN_STATUS_STOPPED, 0);


### PR DESCRIPTION
…connect

Reason for change: if WAN is configured as MAPT or IPv6 Only and v6 renew packet recived,
                   wan-status is goig to stopped, which is causing v6 default route delete.
Test Procedure:
1.)Test MAPT behaviour with Docsis and WANoE line. Risks: High
Priority: P1
Signed-off-by: kulvendra singh <kulvendra.singh@sky.uk>