### PR TITLE
RDKB-56964 :The AutoWan Selection Timer is not functioning as intended 

### DIFF
--- a/source/WanManager/wanmgr_interface_sm.c
+++ b/source/WanManager/wanmgr_interface_sm.c
@@ -4255,6 +4255,12 @@ int WanMgr_StartInterfaceStateMachine(WanMgr_IfaceSM_Controller_t *wanIf)
     else
     {
         CcspTraceInfo(("%s %d - WanManager State Machine Thread Started Successfully\n", __FUNCTION__, __LINE__ ));
+        DML_VIRTUAL_IFACE* p_VirtIf = WanMgr_getVirtualIface_locked(wanIfLocal->interfaceIdx, wanIfLocal->VirIfIdx);
+        if(p_VirtIf != NULL )
+        {
+            p_VirtIf->Interface_SM_Running = TRUE;
+            WanMgr_VirtualIfaceData_release(p_VirtIf);
+        }
     }
     return iErrorCode ;
 }

--- a/source/WanManager/wanmgr_interface_sm.c
+++ b/source/WanManager/wanmgr_interface_sm.c
@@ -4255,12 +4255,6 @@ int WanMgr_StartInterfaceStateMachine(WanMgr_IfaceSM_Controller_t *wanIf)
     else
     {
         CcspTraceInfo(("%s %d - WanManager State Machine Thread Started Successfully\n", __FUNCTION__, __LINE__ ));
-        DML_VIRTUAL_IFACE* p_VirtIf = WanMgr_getVirtualIface_locked(wanIfLocal->interfaceIdx, wanIfLocal->VirIfIdx);
-        if(p_VirtIf != NULL )
-        {
-            p_VirtIf->Interface_SM_Running = TRUE;
-            WanMgr_VirtualIfaceData_release(p_VirtIf);
-        }
     }
     return iErrorCode ;
 }


### PR DESCRIPTION
Reason for change: Removing Physical status check when interface is in scanning state.

Test Procedure:
Updated in Jira.

Risks: none
Priority: P1