### PR TITLE
RDKB-51706 : [MAP-T-HUB6] Index update issue in DM -Device.DHCPv6.Client.1.Interface

### DIFF
--- a/source/TR-181/middle_layer_src/wanmgr_dml_dhcpv6.c
+++ b/source/TR-181/middle_layer_src/wanmgr_dml_dhcpv6.c
@@ -852,8 +852,12 @@ Client3_GetParamStringValue
     }
     else if (strcmp(ParamName, "Interface") == 0)
     {
-        DmlGetInstanceByKeywordFromPandM(pDhcpc->Cfg.Interface, &instanceNumber);
-        snprintf(interface, DATAMODEL_PARAM_LENGTH, PAM_IF_TABLE_OBJECT, instanceNumber);
+        DML_VIRTUAL_IFACE *p_VirtIf = WanMgr_GetActiveVirtIfData_locked();
+        if(p_VirtIf != NULL)
+	{
+            snprintf(interface, sizeof(interface), "%s", p_VirtIf->IP.Interface);
+            WanMgrDml_GetIfaceData_release(NULL);
+        }
         if ( interface[0] != '\0' )
         {
             if ( AnscSizeOfString(interface) < *pUlSize)


### PR DESCRIPTION
Reason for change: Wrong interface was passed in case of VDSL, modified to send current wan interface.

Test Procedure:
Updated in Jira.

Risks: none
Priority: P2