### PR TITLE
RDKB-55171:Excessive logging in WANManager on changing the IP Mode

### DIFF
--- a/source/WanManager/wanmgr_interface_sm.c
+++ b/source/WanManager/wanmgr_interface_sm.c
@@ -419,6 +419,15 @@ static void WanMgr_MonitorDhcpApps (WanMgr_IfaceSM_Controller_t* pWanIfaceCtrl)
     {
         // let the caller state handle RefreshDHCP=TRUE scenario
         CcspTraceError(("%s %d: IP Mode change detected, handle RefreshDHCP & later monitor DHCP apps\n", __FUNCTION__, __LINE__));
+        //reset flag here, if the IP mode and source changes are addressed.
+        if(((p_VirtIf->IP.IPv6Source != DML_WAN_IP_SOURCE_DHCP || p_VirtIf->IP.Mode == DML_WAN_IP_MODE_NO_IP) && p_VirtIf->IP.Dhcp4cPid == 0 && p_VirtIf->IP.Dhcp6cPid == 0)||
+            (p_VirtIf->IP.Mode == DML_WAN_IP_MODE_IPV6_ONLY && p_VirtIf->IP.Dhcp4cPid == 0 && p_VirtIf->IP.Dhcp6cPid > 0) ||
+            (p_VirtIf->IP.Mode == DML_WAN_IP_MODE_IPV4_ONLY && p_VirtIf->IP.Dhcp4cPid > 0 && p_VirtIf->IP.Dhcp6cPid == 0) ||
+            (p_VirtIf->IP.Mode == DML_WAN_IP_MODE_DUAL_STACK && p_VirtIf->IP.Dhcp4cPid > 0 && p_VirtIf->IP.Dhcp6cPid > 0))
+        {
+            CcspTraceInfo(("%s %d: IP Mode change processed. Resetting \n", __FUNCTION__, __LINE__));
+            p_VirtIf->IP.RefreshDHCP = FALSE;
+	}	
         return;
     }
 

--- a/source/WanManager/wanmgr_interface_sm.c
+++ b/source/WanManager/wanmgr_interface_sm.c
@@ -425,7 +425,7 @@ static void WanMgr_MonitorDhcpApps (WanMgr_IfaceSM_Controller_t* pWanIfaceCtrl)
             (p_VirtIf->IP.Mode == DML_WAN_IP_MODE_IPV4_ONLY && p_VirtIf->IP.Dhcp4cPid > 0 && p_VirtIf->IP.Dhcp6cPid == 0) ||
             (p_VirtIf->IP.Mode == DML_WAN_IP_MODE_DUAL_STACK && p_VirtIf->IP.Dhcp4cPid > 0 && p_VirtIf->IP.Dhcp6cPid > 0))
         {
-            CcspTraceInfo(("%s %d: IP Mode change processed. Resetting \n", __FUNCTION__, __LINE__));
+            CcspTraceInfo(("%s %d: IP Mode change processed. Resetting flag. \n", __FUNCTION__, __LINE__));
             p_VirtIf->IP.RefreshDHCP = FALSE;
 	}	
         return;


### PR DESCRIPTION
Reason for change: RefreshDHCP Flag was not set to false which led to flooding of logs.

Test Procedure:
Updated in Jira.

Risks: none
Priority: P2