### PR TITLE
RDKBDEV-2924 : Support Dynamic Configuration of PPP LowerLayers

### DIFF
--- a/source/TR-181/middle_layer_src/wanmgr_rdkbus_utils.c
+++ b/source/TR-181/middle_layer_src/wanmgr_rdkbus_utils.c
@@ -1025,6 +1025,32 @@ ANSC_STATUS WanManager_ConfigurePPPSession(DML_VIRTUAL_IFACE* pVirtIf, BOOL PPPE
 
     syscfg_set_commit(NULL, SYSCFG_WAN_INTERFACE_NAME, pVirtIf->Name);
 
+#ifdef DYNAMIC_CONFIGURE_PPP_LOWERLAYER
+    snprintf( acSetParamName, sizeof(acSetParamName), "%s.Name", pVirtIf->VLAN.VLANInUse);
+
+    ret = WanMgr_RdkBus_GetParamValues( VLAN_COMPONENT_NAME, VLAN_DBUS_PATH, acSetParamName, acSetParamValue );
+    if(ret != ANSC_STATUS_SUCCESS)
+    {
+        CcspTraceError(("%s %d DM get %s %s failed\n", __FUNCTION__,__LINE__, acSetParamName, acSetParamValue));
+        return ANSC_STATUS_FAILURE;
+    }
+    strncpy(pVirtIf->Name, acSetParamValue, sizeof(pVirtIf->Name));
+
+    memset(acSetParamName, 0, sizeof(acSetParamName));
+    memset(acSetParamValue, 0, sizeof(acSetParamValue));
+    snprintf( acSetParamName, sizeof(acSetParamName), "%s.LowerLayers", pVirtIf->PPP.Interface);
+    snprintf( acSetParamValue, sizeof(acSetParamValue), WAN_INTERFACE_TABLE, (pVirtIf->baseIfIdx + 1), (pVirtIf->VirIfIdx + 1));
+    ret = WanMgr_RdkBus_SetParamValues( PPPMGR_COMPONENT_NAME, PPPMGR_DBUS_PATH, acSetParamName, acSetParamValue, ccsp_string, TRUE );
+
+    if(ret != ANSC_STATUS_SUCCESS)
+    {
+        CcspTraceError(("%s %d DM set %s %s failed\n", __FUNCTION__,__LINE__, acSetParamName, acSetParamValue));
+        return ANSC_STATUS_FAILURE;
+    }
+
+    CcspTraceInfo(("%s %d DM set %s %s Successful\n", __FUNCTION__,__LINE__, acSetParamName, acSetParamValue));
+#endif
+
     //Set PPP Enable
     CcspTraceInfo(("%s %d %s PPP %s\n", __FUNCTION__,__LINE__, PPPEnable? "Enabling":"Disabling",pVirtIf->PPP.Interface));
     snprintf( acSetParamName, DATAMODEL_PARAM_LENGTH, "%s.Enable", pVirtIf->PPP.Interface );

--- a/source/TR-181/middle_layer_src/wanmgr_rdkbus_utils.h
+++ b/source/TR-181/middle_layer_src/wanmgr_rdkbus_utils.h
@@ -71,6 +71,7 @@ extern token_t sysevent_token;
 #define WAN_CONFIG_PORT_DM_SUFFIX           ".WanConfigPort"
 
 #if defined(WAN_MANAGER_UNIFICATION_ENABLED)
+#define WAN_INTERFACE_TABLE                         "Device.X_RDK_WanManager.Interface.%d.VirtualInterface.%d"
 #define WAN_ENABLE_CUSTOM_CONFIG_PARAM_NAME         "Device.X_RDK_WanManager.Interface.%d.EnableCustomConfig"
 #define WAN_CUSTOM_CONFIG_PATH_PARAM_NAME           "Device.X_RDK_WanManager.Interface.%d.CustomConfigPath"
 #define WAN_CONFIGURE_WAN_ENABLE_PARAM_NAME         "Device.X_RDK_WanManager.Interface.%d.ConfigureWanEnable"


### PR DESCRIPTION
Reason for change:
For the VlanSensing of PPP, dynamic configuration of PPP LowerLayers must be done by WanManager.

Test Procedure: verify VlanSensing with Enabling Dynamic PPP LowerLayers support.
Risks: None.