### PR TITLE
RDKB-57103:Observed WAN going down in CPE , 7 mins after FR

### DIFF
--- a/source/WanManager/wanmgr_interface_sm.c
+++ b/source/WanManager/wanmgr_interface_sm.c
@@ -3924,6 +3924,8 @@ static eWanState_t wan_state_refreshing_wan(WanMgr_IfaceSM_Controller_t* pWanIfa
         p_VirtIf->Enable == FALSE ||
         pInterface->BaseInterfaceStatus !=  WAN_IFACE_PHY_STATUS_UP)
     {
+         p_VirtIf->Reset = FALSE;
+         p_VirtIf->VLAN.Reset = FALSE;
          p_VirtIf->VLAN.Expired = FALSE; //Reset VLAN.Expired
         return wan_transition_physical_interface_down(pWanIfaceCtrl);
     }


### PR DESCRIPTION
Reason for change: Observed WAN going down in CPE , 7 mins after FR and continuous
                                flooding of "TRANSITION REFRESHING WAN" events seen in logs
Test Procedure:
1.)Test MAPT Line with FR.
Risks: High
Priority: P1
Signed-off-by: kulvendra singh <kulvendra.singh@sky.uk>