### PR TITLE
SHARMAN-2786:DHCP Lease Expire Time (ipv4) is not getting updated in …

### DIFF
--- a/source/TR-181/include/wanmgr_dml.h
+++ b/source/TR-181/include/wanmgr_dml.h
@@ -304,6 +304,7 @@ typedef struct _WANMGR_IPV4_DATA
     char dnsServer[BUFLEN_64];         /** New dns Server, if addressAssigned==TRUE */
     char dnsServer1[BUFLEN_64];        /** New dns Server, if addressAssigned==TRUE */
     uint32_t mtuSize;                  /** New MTU size, if mtuAssigned==TRUE */
+    uint32_t leaseReceivedTime;        /** Lease received time*/
 #if defined(FEATURE_RDKB_CONFIGURABLE_WAN_INTERFACE)
     int32_t timeOffset;                /** New time offset, if addressAssigned==TRUE */
     bool isTimeOffsetAssigned;         /** Is the time offset assigned ? */

--- a/source/WanManager/wanmgr_dhcpv4_apis.c
+++ b/source/WanManager/wanmgr_dhcpv4_apis.c
@@ -67,7 +67,9 @@ extern char g_Subsystem[32];
 
 #define P2P_SUB_NET_MASK   "255.255.255.255"
 #define DHCP_STATE_UP      "Up"
+#define DHCP_STATE_RENEW   "renew"
 #define DHCP_STATE_DOWN    "Down"
+#define DHCP_STATE_BOUND   "bound"
 
 static ANSC_STATUS wanmgr_dchpv4_get_ipc_msg_info(WANMGR_IPV4_DATA* pDhcpv4Data, ipc_dhcpv4_data_t* pIpcIpv4Data)
 {
@@ -212,6 +214,8 @@ ANSC_STATUS wanmgr_handle_dhcpv4_event_data(DML_VIRTUAL_IFACE* pVirtIf)
 
         // update current IPv4 data
         wanmgr_dchpv4_get_ipc_msg_info(&(pVirtIf->IP.Ipv4Data), pDhcpcInfo);
+
+	pVirtIf->IP.Ipv4Data.leaseReceivedTime = up_time;
 
         /* Assign the address to the inetrface when received. Remaining configurations are updated when activated from VISM*/
         CcspTraceInfo(("%s %d -  Received Ipv4 lease for interface %s. Configuring address on interface\n", __FUNCTION__, __LINE__, pVirtIf->IP.Ipv4Data.ifname));
@@ -933,9 +937,13 @@ WanMgr_DmlDhcpcGetInfo
         pInfo->IPRouters[0].Value  = inet_addr(p_VirtIf->IP.Ipv4Data.gateway);
         pInfo->DNSServers[0].Value = inet_addr(p_VirtIf->IP.Ipv4Data.dnsServer);
         pInfo->DNSServers[1].Value = inet_addr(p_VirtIf->IP.Ipv4Data.dnsServer1);
-        pInfo->DHCPStatus          = (strcmp(p_VirtIf->IP.Ipv4Data.dhcpState, DHCP_STATE_UP) == 0) ? DML_DHCPC_STATUS_Bound : DML_DHCPC_STATUS_Init;
+        pInfo->DHCPServer.Value = inet_addr(p_VirtIf->IP.Ipv4Data.dhcpServerId);
+	pInfo->DHCPStatus = ((strcmp(p_VirtIf->IP.Ipv4Data.dhcpState, DHCP_STATE_BOUND) == 0) || 
+                       (strcmp(p_VirtIf->IP.Ipv4Data.dhcpState, DHCP_STATE_RENEW) == 0)) ? DML_DHCPC_STATUS_Bound : DML_DHCPC_STATUS_Init;
+        pInfo->LeaseTimeRemaining  = (p_VirtIf->IP.Ipv4Data.leaseReceivedTime + p_VirtIf->IP.Ipv4Data.leaseTime) - WanManager_getUpTime();
         WanMgrDml_GetIfaceData_release(NULL);
     }
+
     pInfo->NumDnsServers = 2;
     pInfo->NumIPRouters = 1;
     return ANSC_STATUS_SUCCESS;


### PR DESCRIPTION
…GUI>Network page

Reason for change:DHCP Lease Expire Time (ipv4) is not getting updated in GUI>Network page Test Procedure:
1.)Test DHCP v4 Remaining Lease on GUI.
Risks: Medium
Priority: P2
Signed-off-by: kulvendra singh <kulvendra.singh@sky.uk>