### PR TITLE
CBR2-2096 : [Field][DA] Internet LED fast blinking in 7.6p3s1.

### DIFF
--- a/source/WanManager/wanmgr_sysevents.c
+++ b/source/WanManager/wanmgr_sysevents.c
@@ -1440,6 +1440,10 @@ ANSC_STATUS wanmgr_services_restart()
 #ifdef SNMPV3_ENABLED
     wanmgr_snmpv3_restart();
 #endif // SNMPV3_ENABLED
+
+#ifdef _CBR2_PRODUCT_REQ_
+    v_secure_system("sh /etc/network_response.sh &");
+#endif // _CBR2_PRODUCT_REQ_
     return ANSC_STATUS_SUCCESS;
 }
 


### PR DESCRIPTION
Reason for change:
Network response script has not been invoked after wan started due to this LED status was not proper and CP status also not proper.

Test Procedure:
1. LED should behave properly
2. CP should work without any issue
3. WAN functionality should work without any issue

Risks: Low