### PR TITLE
RDKB-57627 : Incorrect IPv6 address calculation in MAPT lines if the …

### DIFF
--- a/source/WanManager/wanmgr_net_utils.c
+++ b/source/WanManager/wanmgr_net_utils.c
@@ -1501,7 +1501,7 @@ static int WanManager_ConfigureIpv6Sysevents(char *pdIPv6Prefix, char *ipAddress
         return ret;
     }
 
-    snprintf(ipv6AddressString, sizeof(ipv6AddressString), "%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x", in6Addr.s6_addr[0], in6Addr.s6_addr[1], in6Addr.s6_addr[2], in6Addr.s6_addr[3], in6Addr.s6_addr[4], in6Addr.s6_addr[5], in6Addr.s6_addr[6], in6Addr.s6_addr[7], 0x0, 0x0, ipAddressBytes[3], ipAddressBytes[2], ipAddressBytes[1], ipAddressBytes[0], 0x0, psidValue);
+    snprintf(ipv6AddressString, sizeof(ipv6AddressString), "%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x", in6Addr.s6_addr[0], in6Addr.s6_addr[1], in6Addr.s6_addr[2], in6Addr.s6_addr[3], in6Addr.s6_addr[4], in6Addr.s6_addr[5], in6Addr.s6_addr[6], in6Addr.s6_addr[7], 0x0, 0x0, ipAddressBytes[3], ipAddressBytes[2], ipAddressBytes[1], ipAddressBytes[0], ((psidValue >> 8) & 0xFF ), (psidValue & 0xFF));
 
     return ret;
 }


### PR DESCRIPTION
…PSID is more than 255.

Reason for change:  Incorrect IPv6 address calculation in MAPT lines if the PSID is more than 255.

Test Procedure:
MAPT should work without any regression

Risks: none
Priority: P1