### PR TITLE
RDKCOM-5173 REFPLTB-3128: [TDK][AUTO][RPI4][CELLULAR MANAGER] Switching back to ethwan from cellular mode not working as expected

### DIFF
--- a/source/WanManager/wanmgr_policy_auto_impl.c
+++ b/source/WanManager/wanmgr_policy_auto_impl.c
@@ -270,7 +270,7 @@ static void WanMgr_Policy_Auto_GetHighPriorityIface(WanMgr_Policy_Controller_t *
                     }
                     // pWanIfaceData - is Wan-Enabled & has valid Priority
                     if(pWanIfaceData->Selection.Priority < iSelPriority
-#if (defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_))
+#if (defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_))
                         //TODO: this is a workaround to support upgarde from Comcast autowan policy to Unification build
                         || isLastActiveLinkFromSysCfg(pWanIfaceData)
 #endif    


### PR DESCRIPTION
Reason for change: As Erouter IP is not being restored without Factory-Reset.
Test Procedure: Erouter0 IP should get restored while switching over from LTE to WanOE and on reboots as well.
Risks: None.