### PR TITLE
RDKB-57540 : UDHCPC process is not started by SelfHeal if failed to s…

### DIFF
--- a/source/TR-181/include/wanmgr_dml.h
+++ b/source/TR-181/include/wanmgr_dml.h
@@ -375,8 +375,8 @@ typedef struct _DML_WANIFACE_IP
     WANMGR_IPV6_RA_DATA         Ipv6Route;
     ipc_dhcpv4_data_t*          pIpcIpv4Data;
     ipc_dhcpv6_data_t*          pIpcIpv6Data;
-    INT                        Dhcp4cPid;
-    INT                        Dhcp6cPid;
+    int                         Dhcp4cPid;
+    int                         Dhcp6cPid;
 } DML_WANIFACE_IP;
 
 #ifdef FEATURE_MAPT

--- a/source/TR-181/include/wanmgr_dml.h
+++ b/source/TR-181/include/wanmgr_dml.h
@@ -375,8 +375,8 @@ typedef struct _DML_WANIFACE_IP
     WANMGR_IPV6_RA_DATA         Ipv6Route;
     ipc_dhcpv4_data_t*          pIpcIpv4Data;
     ipc_dhcpv6_data_t*          pIpcIpv6Data;
-    UINT                        Dhcp4cPid;
-    UINT                        Dhcp6cPid;
+    INT                        Dhcp4cPid;
+    INT                        Dhcp6cPid;
 } DML_WANIFACE_IP;
 
 #ifdef FEATURE_MAPT

--- a/source/WanManager/wanmgr_interface_sm.c
+++ b/source/WanManager/wanmgr_interface_sm.c
@@ -447,7 +447,7 @@ static void WanMgr_MonitorDhcpApps (WanMgr_IfaceSM_Controller_t* pWanIfaceCtrl)
         {
             CcspTraceInfo(("%s %d: IP Mode change processed. Resetting flag. \n", __FUNCTION__, __LINE__));
             p_VirtIf->IP.RefreshDHCP = FALSE;
-	}	
+	    }	
         return;
     }
 

--- a/source/WanManager/wanmgr_interface_sm.c
+++ b/source/WanManager/wanmgr_interface_sm.c
@@ -460,14 +460,11 @@ static void WanMgr_MonitorDhcpApps (WanMgr_IfaceSM_Controller_t* pWanIfaceCtrl)
         (p_VirtIf->IP.Dhcp4cPid > 0 &&                                                                          // dhcp started by ISM
         WanMgr_IsPIDRunning(p_VirtIf->IP.Dhcp4cPid) != TRUE)))                                                  // but DHCP client not running
     {
-        if (p_VirtIf->IP.Dhcp4cPid != -1 )
-        {
-#ifdef ENABLE_FEATURE_TELEMETRY2_0
-            t2_event_d("SYS_ERROR_DHCPV4Client_notrunning", 1);
-#endif
-        }
         p_VirtIf->IP.Dhcp4cPid = WanManager_StartDhcpv4Client(p_VirtIf, pInterface->Name, pInterface->IfaceType);
         CcspTraceInfo(("%s %d - SELFHEAL - Started dhcpc on interface %s, dhcpv4_pid %d \n", __FUNCTION__, __LINE__, p_VirtIf->Name, p_VirtIf->IP.Dhcp4cPid));
+#ifdef ENABLE_FEATURE_TELEMETRY2_0
+        t2_event_d("SYS_ERROR_DHCPV4Client_notrunning", 1);
+#endif
     }
 
     //Check if IPv6 dhcp client is still running - handling runtime crash of dhcp client
@@ -477,14 +474,11 @@ static void WanMgr_MonitorDhcpApps (WanMgr_IfaceSM_Controller_t* pWanIfaceCtrl)
         (p_VirtIf->IP.Dhcp6cPid > 0 &&                                                                          // dhcp started by ISM
         WanMgr_IsPIDRunning(p_VirtIf->IP.Dhcp6cPid) != TRUE)))                                                   // but DHCP client not running
     {
-        if (p_VirtIf->IP.Dhcp6cPid != -1 )
-        {
-#ifdef ENABLE_FEATURE_TELEMETRY2_0
-            t2_event_d("SYS_ERROR_DHCPV6Client_notrunning", 1);
-#endif
-        }
         p_VirtIf->IP.Dhcp6cPid = WanManager_StartDhcpv6Client(p_VirtIf, pInterface->IfaceType);
         CcspTraceInfo(("%s %d - SELFHEAL - Started dhcp6c on interface %s, dhcpv6_pid %d \n", __FUNCTION__, __LINE__, p_VirtIf->Name, p_VirtIf->IP.Dhcp6cPid));
+#ifdef ENABLE_FEATURE_TELEMETRY2_0
+        t2_event_d("SYS_ERROR_DHCPV6Client_notrunning", 1);
+#endif
     }
 
     /* Handling Runtime IP.ConnectivityCheckType change */

--- a/source/WanManager/wanmgr_interface_sm.c
+++ b/source/WanManager/wanmgr_interface_sm.c
@@ -470,10 +470,18 @@ static void WanMgr_MonitorDhcpApps (WanMgr_IfaceSM_Controller_t* pWanIfaceCtrl)
     //Check if IPv6 dhcp client is still running - handling runtime crash of dhcp client
     if ((p_VirtIf->IP.Mode == DML_WAN_IP_MODE_IPV6_ONLY || p_VirtIf->IP.Mode == DML_WAN_IP_MODE_DUAL_STACK) &&  // IP.Mode supports V6
         p_VirtIf->IP.IPv6Source == DML_WAN_IP_SOURCE_DHCP &&                                                    // uses DHCP client
-        (p_VirtIf->IP.Dhcp6cPid -1 ||                                                                           // DHCP cleint failed to start
+        (p_VirtIf->IP.Dhcp6cPid == -1 ||                                                                           // DHCP cleint failed to start
         (p_VirtIf->IP.Dhcp6cPid > 0 &&                                                                          // dhcp started by ISM
         WanMgr_IsPIDRunning(p_VirtIf->IP.Dhcp6cPid) != TRUE)))                                                   // but DHCP client not running
     {
+        if (p_VirtIf->IP.Dhcp6cPid == -1 )
+        {
+            /* DHCPv6c client can fail to start due to DAD failuer on the link local address. 
+             * This could happen if multiple WAN interfaces are up with same MAC address. Toggling will restart the DAD again.
+             */
+            CcspTraceInfo(("%s %d - DHCPv6c cleint failed to start. Toggeling Ipv6 before retry... \n", __FUNCTION__, __LINE__, p_VirtIf->Name));
+            Force_IPv6_toggle(p_VirtIf->Name); 
+        }
         p_VirtIf->IP.Dhcp6cPid = WanManager_StartDhcpv6Client(p_VirtIf, pInterface->IfaceType);
         CcspTraceInfo(("%s %d - SELFHEAL - Started dhcp6c on interface %s, dhcpv6_pid %d \n", __FUNCTION__, __LINE__, p_VirtIf->Name, p_VirtIf->IP.Dhcp6cPid));
 #ifdef ENABLE_FEATURE_TELEMETRY2_0

--- a/source/WanManager/wanmgr_interface_sm.c
+++ b/source/WanManager/wanmgr_interface_sm.c
@@ -460,7 +460,7 @@ static void WanMgr_MonitorDhcpApps (WanMgr_IfaceSM_Controller_t* pWanIfaceCtrl)
         (p_VirtIf->IP.Dhcp4cPid > 0 &&                                                                          // dhcp started by ISM
         WanMgr_IsPIDRunning(p_VirtIf->IP.Dhcp4cPid) != TRUE)))                                                  // but DHCP client not running
     {
-        if (p_VirtIf->IP.Dhcp6cPid != -1 )
+        if (p_VirtIf->IP.Dhcp4cPid != -1 )
         {
 #ifdef ENABLE_FEATURE_TELEMETRY2_0
             t2_event_d("SYS_ERROR_DHCPV4Client_notrunning", 1);

--- a/source/WanManager/wanmgr_interface_sm.c
+++ b/source/WanManager/wanmgr_interface_sm.c
@@ -2959,6 +2959,7 @@ static eWanState_t wan_transition_standby_deconfig_ips(WanMgr_IfaceSM_Controller
         {
             CcspTraceError(("%s %d - Failed to tear down IPv6 for %s Interface \n", __FUNCTION__, __LINE__, p_VirtIf->Name));
         }
+        p_VirtIf->IP.Ipv6Changed = TRUE; //We have deconfigured Ipv6 from the device. set this flag to configure again when moves back to active.
     }
 
     WanMgr_Configure_accept_ra(p_VirtIf, FALSE);

--- a/source/WanManager/wanmgr_interface_sm.c
+++ b/source/WanManager/wanmgr_interface_sm.c
@@ -477,15 +477,7 @@ static void WanMgr_MonitorDhcpApps (WanMgr_IfaceSM_Controller_t* pWanIfaceCtrl)
         (p_VirtIf->IP.Dhcp6cPid > 0 &&                                                                          // dhcp started by ISM
         WanMgr_IsPIDRunning(p_VirtIf->IP.Dhcp6cPid) != TRUE)))                                                   // but DHCP client not running
     {
-        if (p_VirtIf->IP.Dhcp6cPid == -1 )
-        {
-            /* DHCPv6c client can fail to start due to DAD failuer on the link local address. 
-             * This could happen if multiple WAN interfaces are up with same MAC address. Toggling will restart the DAD again.
-             */
-            CcspTraceInfo(("%s %d - DHCPv6c client failed to start. Toggeling Ipv6 before retry... \n", __FUNCTION__, __LINE__, p_VirtIf->Name));
-            Force_IPv6_toggle(p_VirtIf->Name); 
-        }
-        else
+        if (p_VirtIf->IP.Dhcp6cPid != -1 )
         {
 #ifdef ENABLE_FEATURE_TELEMETRY2_0
             t2_event_d("SYS_ERROR_DHCPV6Client_notrunning", 1);

--- a/source/WanManager/wanmgr_interface_sm.c
+++ b/source/WanManager/wanmgr_interface_sm.c
@@ -460,11 +460,14 @@ static void WanMgr_MonitorDhcpApps (WanMgr_IfaceSM_Controller_t* pWanIfaceCtrl)
         (p_VirtIf->IP.Dhcp4cPid > 0 &&                                                                          // dhcp started by ISM
         WanMgr_IsPIDRunning(p_VirtIf->IP.Dhcp4cPid) != TRUE)))                                                  // but DHCP client not running
     {
+        if (p_VirtIf->IP.Dhcp6cPid != -1 )
+        {
+#ifdef ENABLE_FEATURE_TELEMETRY2_0
+            t2_event_d("SYS_ERROR_DHCPV4Client_notrunning", 1);
+#endif
+        }
         p_VirtIf->IP.Dhcp4cPid = WanManager_StartDhcpv4Client(p_VirtIf, pInterface->Name, pInterface->IfaceType);
         CcspTraceInfo(("%s %d - SELFHEAL - Started dhcpc on interface %s, dhcpv4_pid %d \n", __FUNCTION__, __LINE__, p_VirtIf->Name, p_VirtIf->IP.Dhcp4cPid));
-#ifdef ENABLE_FEATURE_TELEMETRY2_0
-        t2_event_d("SYS_ERROR_DHCPV4Client_notrunning", 1);
-#endif
     }
 
     //Check if IPv6 dhcp client is still running - handling runtime crash of dhcp client
@@ -479,14 +482,17 @@ static void WanMgr_MonitorDhcpApps (WanMgr_IfaceSM_Controller_t* pWanIfaceCtrl)
             /* DHCPv6c client can fail to start due to DAD failuer on the link local address. 
              * This could happen if multiple WAN interfaces are up with same MAC address. Toggling will restart the DAD again.
              */
-            CcspTraceInfo(("%s %d - DHCPv6c cleint failed to start. Toggeling Ipv6 before retry... \n", __FUNCTION__, __LINE__, p_VirtIf->Name));
+            CcspTraceInfo(("%s %d - DHCPv6c client failed to start. Toggeling Ipv6 before retry... \n", __FUNCTION__, __LINE__, p_VirtIf->Name));
             Force_IPv6_toggle(p_VirtIf->Name); 
+        }
+        else
+        {
+#ifdef ENABLE_FEATURE_TELEMETRY2_0
+            t2_event_d("SYS_ERROR_DHCPV6Client_notrunning", 1);
+#endif
         }
         p_VirtIf->IP.Dhcp6cPid = WanManager_StartDhcpv6Client(p_VirtIf, pInterface->IfaceType);
         CcspTraceInfo(("%s %d - SELFHEAL - Started dhcp6c on interface %s, dhcpv6_pid %d \n", __FUNCTION__, __LINE__, p_VirtIf->Name, p_VirtIf->IP.Dhcp6cPid));
-#ifdef ENABLE_FEATURE_TELEMETRY2_0
-        t2_event_d("SYS_ERROR_DHCPV6Client_notrunning", 1);
-#endif
     }
 
     /* Handling Runtime IP.ConnectivityCheckType change */

--- a/source/WanManager/wanmgr_net_utils.c
+++ b/source/WanManager/wanmgr_net_utils.c
@@ -557,7 +557,7 @@ int WanManager_Ipv6AddrUtil(char *ifname, Ipv6OperType opr, int preflft, int val
     return 0;
 }
 
-uint32_t WanManager_StartDhcpv6Client(DML_VIRTUAL_IFACE* pVirtIf, IFACE_TYPE IfaceType)
+int WanManager_StartDhcpv6Client(DML_VIRTUAL_IFACE* pVirtIf, IFACE_TYPE IfaceType)
 {
     if (pVirtIf == NULL)
     {
@@ -565,7 +565,7 @@ uint32_t WanManager_StartDhcpv6Client(DML_VIRTUAL_IFACE* pVirtIf, IFACE_TYPE Ifa
         return 0;
     }
 
-    uint32_t pid = 0;
+    int pid = 0;
     dhcp_params params;
     memset (&params, 0, sizeof(dhcp_params));
     params.ifname = pVirtIf->Name;
@@ -574,7 +574,12 @@ uint32_t WanManager_StartDhcpv6Client(DML_VIRTUAL_IFACE* pVirtIf, IFACE_TYPE Ifa
     CcspTraceInfo(("Enter WanManager_StartDhcpv6Client for  %s \n", pVirtIf->Name));
     WanManager_send_and_receive_rs(pVirtIf);
     pid = start_dhcpv6_client(&params);
-    pVirtIf->IP.Dhcp6cPid = pid ? pid : -1; //if PID is zero
+    if (pid == 0) 
+    {
+        CcspTraceError(("%s %d: dhcpv6 client failed to start. Returing pid -1.\n", __FUNCTION__, __LINE__));
+        pid = -1;
+    }
+    pVirtIf->IP.Dhcp6cPid = pid;
 
     return pid;
 }
@@ -618,7 +623,7 @@ ANSC_STATUS WanManager_StopDhcpv6Client(char * iface_name, DHCP_RELEASE_BEHAVIOU
 }
 
 
-uint32_t WanManager_StartDhcpv4Client(DML_VIRTUAL_IFACE* pVirtIf, char* baseInterface, IFACE_TYPE IfaceType)
+int WanManager_StartDhcpv4Client(DML_VIRTUAL_IFACE* pVirtIf, char* baseInterface, IFACE_TYPE IfaceType)
 {
     if (pVirtIf == NULL)
     {
@@ -631,7 +636,7 @@ uint32_t WanManager_StartDhcpv4Client(DML_VIRTUAL_IFACE* pVirtIf, char* baseInte
     return 0;//TODO:Read and return PID
 #endif
     dhcp_params params;
-    uint32_t pid = 0;
+    int pid = 0;
 
     memset (&params, 0, sizeof(dhcp_params));
     params.ifname = pVirtIf->Name;
@@ -640,7 +645,13 @@ uint32_t WanManager_StartDhcpv4Client(DML_VIRTUAL_IFACE* pVirtIf, char* baseInte
 
     CcspTraceInfo(("Starting DHCPv4 Client for iface: %s \n", params.ifname));
     pid = start_dhcpv4_client(&params);
-    pVirtIf->IP.Dhcp4cPid = pid ? pid : -1;
+
+    if (pid == 0) 
+    {
+        CcspTraceError(("%s %d: dhcpv4 client failed to start. Returing pid -1.\n", __FUNCTION__, __LINE__));
+        pid = -1;
+    }
+    pVirtIf->IP.Dhcp4cPid = pid;
     return pid;
 }
 

--- a/source/WanManager/wanmgr_net_utils.c
+++ b/source/WanManager/wanmgr_net_utils.c
@@ -574,7 +574,7 @@ uint32_t WanManager_StartDhcpv6Client(DML_VIRTUAL_IFACE* pVirtIf, IFACE_TYPE Ifa
     CcspTraceInfo(("Enter WanManager_StartDhcpv6Client for  %s \n", pVirtIf->Name));
     WanManager_send_and_receive_rs(pVirtIf);
     pid = start_dhcpv6_client(&params);
-    pVirtIf->IP.Dhcp6cPid = pid;
+    pVirtIf->IP.Dhcp6cPid = pid ? pid : -1; //if PID is zero
 
     return pid;
 }
@@ -640,7 +640,7 @@ uint32_t WanManager_StartDhcpv4Client(DML_VIRTUAL_IFACE* pVirtIf, char* baseInte
 
     CcspTraceInfo(("Starting DHCPv4 Client for iface: %s \n", params.ifname));
     pid = start_dhcpv4_client(&params);
-    pVirtIf->IP.Dhcp4cPid = pid;
+    pVirtIf->IP.Dhcp4cPid = pid ? pid : -1;
     return pid;
 }
 

--- a/source/WanManager/wanmgr_net_utils.h
+++ b/source/WanManager/wanmgr_net_utils.h
@@ -92,7 +92,7 @@ typedef enum {
  * @param isPPP indicates PPP enabled or nor
  * @return ANSC_STATUS_SUCCESS upon success else returned error code.
  ***************************************************************************/
-uint32_t WanManager_StartDhcpv6Client(DML_VIRTUAL_IFACE* pVirtIf, IFACE_TYPE IfaceType);
+int WanManager_StartDhcpv6Client(DML_VIRTUAL_IFACE* pVirtIf, IFACE_TYPE IfaceType);
 
 /***************************************************************************
  * @brief API used to stop Dhcpv6 client application.
@@ -106,7 +106,7 @@ ANSC_STATUS WanManager_StopDhcpv6Client(char * iface_name, DHCP_RELEASE_BEHAVIOU
  * @param intf Interface name on which the dhcpv4 needs to start
  * @return ANSC_STATUS_SUCCESS upon success else returned error code.
  ***************************************************************************/
-uint32_t WanManager_StartDhcpv4Client(DML_VIRTUAL_IFACE* pVirtIf, char* baseInterface ,IFACE_TYPE IfaceType);
+int WanManager_StartDhcpv4Client(DML_VIRTUAL_IFACE* pVirtIf, char* baseInterface ,IFACE_TYPE IfaceType);
 
 /***************************************************************************
  * @brief API used to stop Dhcpv4 client application.
@@ -153,7 +153,7 @@ int WanManager_Ipv6AddrUtil(char *ifname,Ipv6OperType opr,int preflft,int vallft
  * @param pid PID of the process to be checked
  * @return TRUE upon success else FALSE returned
  ***************************************************************************/
-BOOL WanMgr_IsPIDRunning(UINT pid);
+BOOL WanMgr_IsPIDRunning(int pid);
 
 #if defined(FEATURE_464XLAT)
 int xlat_configure(char *interface, char *xlat_address);

--- a/source/WanManager/wanmgr_utils.c
+++ b/source/WanManager/wanmgr_utils.c
@@ -704,7 +704,7 @@ void WanManager_DoSystemAction(const char *from, char *cmd)
  * @param pid PID of the process to be checked
  * @return TRUE upon success else FALSE returned
  ***************************************************************************/
-BOOL WanMgr_IsPIDRunning(UINT pid)
+BOOL WanMgr_IsPIDRunning(int pid)
 {
     /* If sig is 0 (the null signal), error checking is performed but no signal is actually sent. 
        The null signal can be used to check the validity of pid. */


### PR DESCRIPTION
…tart.

Reason for change: Current Selfheal thread only handles if the dhcpv4/6 clients are killed runtime. Adding code to handle the case if clients are failed to start.

Test Procedure:
Udhcpc should be started by selfheal monitor thread if it failed to start.

Risks: none
Priority: P1