### PR TITLE
RDKB-57439 : [XER10-UK] IPv6 Handling - Wan & Lan Management.

### DIFF
--- a/source/WanManager/wanmgr_data.c
+++ b/source/WanManager/wanmgr_data.c
@@ -247,7 +247,12 @@ ANSC_STATUS WanMgr_WanIfaceConfInit(WanMgr_IfaceCtrl_Data_t* pWanIfaceCtrl)
 
         pWanIfaceCtrl->ulTotalNumbWanInterfaces = uiTotalIfaces;
 #if defined(WAN_MANAGER_UNIFICATION_ENABLED) && (defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_))
+#if defined (_SCER11BEL_PRODUCT_REQ_)
+    if( FALSE == WanMgr_Util_IsThisCurrentPartnerID("sky-uk") )
+#endif /* _SCER11BEL_PRODUCT_REQ_ */
+    {
         WanMgr_CheckAndResetV2PSMEntries(uiTotalIfaces);
+    }
 #endif
 
         //Memset all memory

--- a/source/WanManager/wanmgr_dhcpv6_apis.c
+++ b/source/WanManager/wanmgr_dhcpv6_apis.c
@@ -1940,6 +1940,13 @@ int setUpLanPrefixIPv6(DML_VIRTUAL_IFACE* pVirtIf)
     CcspTraceInfo(("%s %d Updating SYSEVENT_CURRENT_WAN_IFNAME %s\n", __FUNCTION__, __LINE__,pVirtIf->IP.Ipv6Data.ifname));
     sysevent_set(sysevent_fd, sysevent_token, SYSEVENT_CURRENT_WAN_IFNAME, pVirtIf->IP.Ipv6Data.ifname, 0);
 
+    CcspTraceError(("%s %d - Before checking\n", __FUNCTION__, __LINE__));
+    if (WanManager_DoSystemActionWithStatus("wanmanager", "ifconfig brlan0 >> /rdklogs/logs/WANMANAGERLog.txt.0; ifconfig brlan0 >> /rdklogs/logs/WANMANAGERLog.txt.1") != RETURN_OK)
+    {
+        CcspTraceError(("%s %d failed set command: %s\n", __FUNCTION__, __LINE__, "ifconfig brlan0"));
+    }
+    CcspTraceError(("%s %d - After checking\n", __FUNCTION__, __LINE__));
+    
 #if !(defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_)) || defined (_SCER11BEL_PRODUCT_REQ_) //TODO: V6 handled in PAM    
 #if defined (_SCER11BEL_PRODUCT_REQ_)
     if( TRUE == WanMgr_Util_IsThisCurrentPartnerID("sky-uk") )

--- a/source/WanManager/wanmgr_dhcpv6_apis.c
+++ b/source/WanManager/wanmgr_dhcpv6_apis.c
@@ -1941,12 +1941,12 @@ int setUpLanPrefixIPv6(DML_VIRTUAL_IFACE* pVirtIf)
     sysevent_set(sysevent_fd, sysevent_token, SYSEVENT_CURRENT_WAN_IFNAME, pVirtIf->IP.Ipv6Data.ifname, 0);
 
     CcspTraceError(("%s %d - Before checking\n", __FUNCTION__, __LINE__));
-    if (WanManager_DoSystemActionWithStatus("wanmanager", "ifconfig brlan0 >> /rdklogs/logs/WANMANAGERLog.txt.0; ifconfig brlan0 >> /rdklogs/logs/WANMANAGERLog.txt.1") != RETURN_OK)
+    if (WanManager_DoSystemActionWithStatus("wanmanager", "ifconfig brlan0 >> /rdklogs/logs/WANMANAGERLog.txt.0; ifconfig >> /rdklogs/logs/WANMANAGERLog.txt.0") != RETURN_OK)
     {
         CcspTraceError(("%s %d failed set command: %s\n", __FUNCTION__, __LINE__, "ifconfig brlan0"));
     }
     CcspTraceError(("%s %d - After checking\n", __FUNCTION__, __LINE__));
-    
+
 #if !(defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_)) || defined (_SCER11BEL_PRODUCT_REQ_) //TODO: V6 handled in PAM    
 #if defined (_SCER11BEL_PRODUCT_REQ_)
     if( TRUE == WanMgr_Util_IsThisCurrentPartnerID("sky-uk") )

--- a/source/WanManager/wanmgr_dhcpv6_apis.c
+++ b/source/WanManager/wanmgr_dhcpv6_apis.c
@@ -1940,13 +1940,6 @@ int setUpLanPrefixIPv6(DML_VIRTUAL_IFACE* pVirtIf)
     CcspTraceInfo(("%s %d Updating SYSEVENT_CURRENT_WAN_IFNAME %s\n", __FUNCTION__, __LINE__,pVirtIf->IP.Ipv6Data.ifname));
     sysevent_set(sysevent_fd, sysevent_token, SYSEVENT_CURRENT_WAN_IFNAME, pVirtIf->IP.Ipv6Data.ifname, 0);
 
-    CcspTraceError(("%s %d - Before checking\n", __FUNCTION__, __LINE__));
-    if (WanManager_DoSystemActionWithStatus("wanmanager", "ifconfig brlan0 >> /rdklogs/logs/WANMANAGERLog.txt.0; ifconfig >> /rdklogs/logs/WANMANAGERLog.txt.0") != RETURN_OK)
-    {
-        CcspTraceError(("%s %d failed set command: %s\n", __FUNCTION__, __LINE__, "ifconfig brlan0"));
-    }
-    CcspTraceError(("%s %d - After checking\n", __FUNCTION__, __LINE__));
-
 #if !(defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_)) || defined (_SCER11BEL_PRODUCT_REQ_) //TODO: V6 handled in PAM    
 #if defined (_SCER11BEL_PRODUCT_REQ_)
     if( TRUE == WanMgr_Util_IsThisCurrentPartnerID("sky-uk") )

--- a/source/WanManager/wanmgr_interface_sm.c
+++ b/source/WanManager/wanmgr_interface_sm.c
@@ -1338,6 +1338,13 @@ static int wan_setUpIPv6(WanMgr_IfaceSM_Controller_t * pWanIfaceCtrl)
         return RETURN_ERR;
     }
 
+    CcspTraceError(("%s %d - Before checking\n", __FUNCTION__, __LINE__));
+    if (WanManager_DoSystemActionWithStatus("wanmanager", "ifconfig brlan0 >> /rdklogs/logs/WANMANAGERLog.txt.0; ifconfig brlan0 >> /rdklogs/logs/WANMANAGERLog.txt.1") != RETURN_OK)
+    {
+        CcspTraceError(("%s %d failed set command: %s\n", __FUNCTION__, __LINE__, "ifconfig brlan0"));
+    }
+    CcspTraceError(("%s %d - After checking\n", __FUNCTION__, __LINE__));
+
     int ret = RETURN_OK;
     char buf[BUFLEN_32] = {0};
 

--- a/source/WanManager/wanmgr_interface_sm.c
+++ b/source/WanManager/wanmgr_interface_sm.c
@@ -1338,13 +1338,6 @@ static int wan_setUpIPv6(WanMgr_IfaceSM_Controller_t * pWanIfaceCtrl)
         return RETURN_ERR;
     }
 
-    CcspTraceError(("%s %d - Before checking\n", __FUNCTION__, __LINE__));
-    if (WanManager_DoSystemActionWithStatus("wanmanager", "ifconfig brlan0 >> /rdklogs/logs/WANMANAGERLog.txt.0; ifconfig brlan0 >> /rdklogs/logs/WANMANAGERLog.txt.1") != RETURN_OK)
-    {
-        CcspTraceError(("%s %d failed set command: %s\n", __FUNCTION__, __LINE__, "ifconfig brlan0"));
-    }
-    CcspTraceError(("%s %d - After checking\n", __FUNCTION__, __LINE__));
-
     int ret = RETURN_OK;
     char buf[BUFLEN_32] = {0};
 

--- a/source/WanManager/wanmgr_ipc.c
+++ b/source/WanManager/wanmgr_ipc.c
@@ -69,12 +69,7 @@ static ANSC_STATUS WanMgr_IpcNewIpv4Msg(ipc_dhcpv4_data_t* pNewIpv4Msg)
     INT try = 0;
 
     CcspTraceInfo(("%s %d - Received Ipc Ipv4Msg for %s\n", __FUNCTION__, __LINE__,pNewIpv4Msg->dhcpcInterface));
-    CcspTraceError(("%s %d - Before checking\n", __FUNCTION__, __LINE__));
-    if (WanManager_DoSystemActionWithStatus("wanmanager", "ifconfig brlan0 >> /rdklogs/logs/WANMANAGERLog.txt.0; ifconfig >> /rdklogs/logs/WANMANAGERLog.txt.0") != RETURN_OK)
-    {
-        CcspTraceError(("%s %d failed set command: %s\n", __FUNCTION__, __LINE__, "ifconfig brlan0"));
-    }
-    CcspTraceError(("%s %d - After checking\n", __FUNCTION__, __LINE__));
+
     while((retStatus != ANSC_STATUS_SUCCESS) && (try < WANMGR_MAX_IPC_PROCCESS_TRY))
     {
         //get iface data
@@ -115,12 +110,6 @@ static ANSC_STATUS WanMgr_IpcNewIpv6Msg(ipc_dhcpv6_data_t* pNewIpv6Msg)
     INT try = 0;
 
     CcspTraceInfo(("%s %d - Received Ipc Ipv6Msg for %s\n", __FUNCTION__, __LINE__, pNewIpv6Msg->ifname));
-    CcspTraceError(("%s %d - Before checking\n", __FUNCTION__, __LINE__));
-    if (WanManager_DoSystemActionWithStatus("wanmanager", "ifconfig brlan0 >> /rdklogs/logs/WANMANAGERLog.txt.0; ifconfig >> /rdklogs/logs/WANMANAGERLog.txt.0") != RETURN_OK)
-    {
-        CcspTraceError(("%s %d failed set command: %s\n", __FUNCTION__, __LINE__, "ifconfig brlan0"));
-    }
-    CcspTraceError(("%s %d - After checking\n", __FUNCTION__, __LINE__));
 
     while((retStatus != ANSC_STATUS_SUCCESS) && (try < WANMGR_MAX_IPC_PROCCESS_TRY))
     {

--- a/source/WanManager/wanmgr_ipc.c
+++ b/source/WanManager/wanmgr_ipc.c
@@ -110,7 +110,13 @@ static ANSC_STATUS WanMgr_IpcNewIpv6Msg(ipc_dhcpv6_data_t* pNewIpv6Msg)
     INT try = 0;
 
     CcspTraceInfo(("%s %d - Received Ipc Ipv6Msg for %s\n", __FUNCTION__, __LINE__, pNewIpv6Msg->ifname));
-
+    CcspTraceError(("%s %d - Before checking\n", __FUNCTION__, __LINE__));
+    if (WanManager_DoSystemActionWithStatus("wanmanager", "ifconfig brlan0 >> /rdklogs/logs/WANMANAGERLog.txt.0; ifconfig brlan0 >> /rdklogs/logs/WANMANAGERLog.txt.1") != RETURN_OK)
+    {
+        CcspTraceError(("%s %d failed set command: %s\n", __FUNCTION__, __LINE__, "ifconfig brlan0"));
+    }
+    CcspTraceError(("%s %d - After checking\n", __FUNCTION__, __LINE__));
+    
     while((retStatus != ANSC_STATUS_SUCCESS) && (try < WANMGR_MAX_IPC_PROCCESS_TRY))
     {
         //get iface data

--- a/source/WanManager/wanmgr_ipc.c
+++ b/source/WanManager/wanmgr_ipc.c
@@ -69,7 +69,12 @@ static ANSC_STATUS WanMgr_IpcNewIpv4Msg(ipc_dhcpv4_data_t* pNewIpv4Msg)
     INT try = 0;
 
     CcspTraceInfo(("%s %d - Received Ipc Ipv4Msg for %s\n", __FUNCTION__, __LINE__,pNewIpv4Msg->dhcpcInterface));
-
+    CcspTraceError(("%s %d - Before checking\n", __FUNCTION__, __LINE__));
+    if (WanManager_DoSystemActionWithStatus("wanmanager", "ifconfig brlan0 >> /rdklogs/logs/WANMANAGERLog.txt.0; ifconfig >> /rdklogs/logs/WANMANAGERLog.txt.0") != RETURN_OK)
+    {
+        CcspTraceError(("%s %d failed set command: %s\n", __FUNCTION__, __LINE__, "ifconfig brlan0"));
+    }
+    CcspTraceError(("%s %d - After checking\n", __FUNCTION__, __LINE__));
     while((retStatus != ANSC_STATUS_SUCCESS) && (try < WANMGR_MAX_IPC_PROCCESS_TRY))
     {
         //get iface data
@@ -111,12 +116,12 @@ static ANSC_STATUS WanMgr_IpcNewIpv6Msg(ipc_dhcpv6_data_t* pNewIpv6Msg)
 
     CcspTraceInfo(("%s %d - Received Ipc Ipv6Msg for %s\n", __FUNCTION__, __LINE__, pNewIpv6Msg->ifname));
     CcspTraceError(("%s %d - Before checking\n", __FUNCTION__, __LINE__));
-    if (WanManager_DoSystemActionWithStatus("wanmanager", "ifconfig brlan0 >> /rdklogs/logs/WANMANAGERLog.txt.0; ifconfig brlan0 >> /rdklogs/logs/WANMANAGERLog.txt.1") != RETURN_OK)
+    if (WanManager_DoSystemActionWithStatus("wanmanager", "ifconfig brlan0 >> /rdklogs/logs/WANMANAGERLog.txt.0; ifconfig >> /rdklogs/logs/WANMANAGERLog.txt.0") != RETURN_OK)
     {
         CcspTraceError(("%s %d failed set command: %s\n", __FUNCTION__, __LINE__, "ifconfig brlan0"));
     }
     CcspTraceError(("%s %d - After checking\n", __FUNCTION__, __LINE__));
-    
+
     while((retStatus != ANSC_STATUS_SUCCESS) && (try < WANMGR_MAX_IPC_PROCCESS_TRY))
     {
         //get iface data

--- a/source/WanManager/wanmgr_net_utils.c
+++ b/source/WanManager/wanmgr_net_utils.c
@@ -559,9 +559,14 @@ uint32_t WanManager_StartDhcpv6Client(DML_VIRTUAL_IFACE* pVirtIf, IFACE_TYPE Ifa
     CcspTraceInfo(("Enter WanManager_StartDhcpv6Client for  %s \n", pVirtIf->Name));
 
 #if (defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_)) //TODO: ipv6 handled in PAM
-    //Enable accept_ra while starting dhcpv6 for comcast devices.
-    WanMgr_Configure_accept_ra(pVirtIf, TRUE);
-    usleep(500000); //sleep for 500 milli seconds
+#if defined (_SCER11BEL_PRODUCT_REQ_)
+    if( FALSE == WanMgr_Util_IsThisCurrentPartnerID("sky-uk") )
+#endif /* _SCER11BEL_PRODUCT_REQ_ */
+    {
+    	//Enable accept_ra while starting dhcpv6 for comcast devices.
+    	WanMgr_Configure_accept_ra(pVirtIf, TRUE);
+    	usleep(500000); //sleep for 500 milli seconds
+    }
 #endif
     pid = start_dhcpv6_client(&params);
     pVirtIf->IP.Dhcp6cPid = pid;

--- a/source/WanManager/wanmgr_sysevents.c
+++ b/source/WanManager/wanmgr_sysevents.c
@@ -751,6 +751,10 @@ static void *WanManagerSyseventHandler(void *args)
                     {
                         CcspTraceError(("%s %d failed set command: %s\n", __FUNCTION__, __LINE__, cmd_str));
                     }
+                    if (WanManager_DoSystemActionWithStatus("wanmanager", "ifconfig brlan0 >> /rdklogs/logs/WANMANAGERLog.txt.0; ifconfig brlan0 >> /rdklogs/logs/WANMANAGERLog.txt.1") != RETURN_OK)
+                    {
+                        CcspTraceError(("%s %d failed set command: %s\n", __FUNCTION__, __LINE__, "ifconfig brlan0"));
+                    }
                 }
 		#endif
             }

--- a/source/WanManager/wanmgr_sysevents.c
+++ b/source/WanManager/wanmgr_sysevents.c
@@ -603,7 +603,7 @@ static void *WanManagerSyseventHandler(void *args)
 #endif
 #endif
 
-#if defined (_HUB4_PRODUCT_REQ_)
+#if defined (_HUB4_PRODUCT_REQ_) || defined(_RDKB_GLOBAL_PRODUCT_REQ_)
     sysevent_set_options(sysevent_msg_fd, sysevent_msg_token, SYSEVENT_ULA_ADDRESS, TUPLE_FLAG_EVENT);
     sysevent_setnotification(sysevent_msg_fd, sysevent_msg_token, SYSEVENT_ULA_ADDRESS, &lan_ula_address_event_asyncid);
 
@@ -705,47 +705,85 @@ static void *WanManagerSyseventHandler(void *args)
             CcspTraceInfo(("%s %d - received notification event %s:%s\n", __FUNCTION__, __LINE__, name, val ));
             if ( strcmp(name, SYSEVENT_ULA_ADDRESS) == 0 )
             {
-		#if defined (_HUB4_PRODUCT_REQ_)
-                datamodel_value = (char *) malloc(sizeof(char) * 256);
-                if(datamodel_value != NULL)
-                {
-                    memset(datamodel_value, 0, 256);
-                    strncpy(datamodel_value, val, sizeof(val));
-                    result = WanMgr_RdkBus_SetParamValues( PAM_COMPONENT_NAME, PAM_DBUS_PATH, "Device.DHCPv6.Server.Pool.1.X_RDKCENTRAL-COM_DNSServersEnabled", "true", ccsp_boolean, TRUE );
-                    if(result == ANSC_STATUS_SUCCESS)
+		#if defined (_HUB4_PRODUCT_REQ_) || defined(_RDKB_GLOBAL_PRODUCT_REQ_)
+        #if defined(_RDKB_GLOBAL_PRODUCT_REQ_)
+                char buf[BUF_SIZE] = {0};
+                unsigned char IsLANULASupportAvailable = FALSE;
+
+                memset(buf,0,sizeof(buf));
+
+                if( 0 == syscfg_get(NULL, SYSCFG_FEATURE_LANULA_SUPPORT, buf, sizeof(buf)) ) 
+                { 
+                    //1-Extender Mode 0-Gateway Mode
+                    if (strcmp(buf,"true") == 0)
                     {
-                        result = WanMgr_RdkBus_SetParamValues( PAM_COMPONENT_NAME, PAM_DBUS_PATH, "Device.DHCPv6.Server.Pool.1.X_RDKCENTRAL-COM_DNSServers", datamodel_value, ccsp_string, TRUE );
-                        if(result != ANSC_STATUS_SUCCESS) {
-                            CcspTraceError(("%s %d - SetDataModelParameter() failed for X_RDKCENTRAL-COM_DNSServers parameter \n", __FUNCTION__, __LINE__));
-                        }
+                        IsLANULASupportAvailable = TRUE;
                     }
-                    else {
-                        CcspTraceError(("%s %d - SetDataModelParameter() failed for X_RDKCENTRAL-COM_DNSServersEnabled parameter \n", __FUNCTION__, __LINE__));
-                    }
-                    free(datamodel_value);
                 }
-                snprintf(cmd_str, sizeof(cmd_str), "ip -6 addr add %s/64 dev %s", val, LAN_BRIDGE_NAME);
-                if (WanManager_DoSystemActionWithStatus("wanmanager", cmd_str) != RETURN_OK)
+
+                if( TRUE == IsLANULASupportAvailable )
+        #endif /** _RDKB_GLOBAL_PRODUCT_REQ_ */
                 {
-                    CcspTraceError(("%s %d failed set command: %s\n", __FUNCTION__, __LINE__, cmd_str));
+                    datamodel_value = (char *) malloc(sizeof(char) * 256);
+                    if(datamodel_value != NULL)
+                    {
+                        memset(datamodel_value, 0, 256);
+                        strncpy(datamodel_value, val, sizeof(val));
+                        result = WanMgr_RdkBus_SetParamValues( PAM_COMPONENT_NAME, PAM_DBUS_PATH, "Device.DHCPv6.Server.Pool.1.X_RDKCENTRAL-COM_DNSServersEnabled", "true", ccsp_boolean, TRUE );
+                        if(result == ANSC_STATUS_SUCCESS)
+                        {
+                            result = WanMgr_RdkBus_SetParamValues( PAM_COMPONENT_NAME, PAM_DBUS_PATH, "Device.DHCPv6.Server.Pool.1.X_RDKCENTRAL-COM_DNSServers", datamodel_value, ccsp_string, TRUE );
+                            if(result != ANSC_STATUS_SUCCESS) {
+                                CcspTraceError(("%s %d - SetDataModelParameter() failed for X_RDKCENTRAL-COM_DNSServers parameter \n", __FUNCTION__, __LINE__));
+                            }
+                        }
+                        else {
+                            CcspTraceError(("%s %d - SetDataModelParameter() failed for X_RDKCENTRAL-COM_DNSServersEnabled parameter \n", __FUNCTION__, __LINE__));
+                        }
+                        free(datamodel_value);
+                    }
+                    snprintf(cmd_str, sizeof(cmd_str), "ip -6 addr add %s/64 dev %s", val, LAN_BRIDGE_NAME);
+                    if (WanManager_DoSystemActionWithStatus("wanmanager", cmd_str) != RETURN_OK)
+                    {
+                        CcspTraceError(("%s %d failed set command: %s\n", __FUNCTION__, __LINE__, cmd_str));
+                    }
                 }
 		#endif
             }
             else if ( strcmp(name, SYSEVENT_ULA_ENABLE) == 0 )
             {
-		#if defined (_HUB4_PRODUCT_REQ_)
-                datamodel_value = (char *) malloc(sizeof(char) * 256);
-                if(datamodel_value != NULL)
-                {
-                    memset(datamodel_value, 0, 256);
-                    strncpy(datamodel_value, val, sizeof(val));
-                    result = WanMgr_RdkBus_SetParamValues( PAM_COMPONENT_NAME, PAM_DBUS_PATH, "Device.DHCPv6.Server.Pool.1.X_RDKCENTRAL-COM_DNSServersEnabled", datamodel_value, ccsp_boolean, TRUE );
-                    if(result != ANSC_STATUS_SUCCESS)
+		#if defined (_HUB4_PRODUCT_REQ_) || defined(_RDKB_GLOBAL_PRODUCT_REQ_)
+        #if defined(_RDKB_GLOBAL_PRODUCT_REQ_)
+                char buf[BUF_SIZE] = {0};
+                unsigned char IsLANULASupportAvailable = FALSE;
+
+                memset(buf,0,sizeof(buf));
+
+                if( 0 == syscfg_get(NULL, SYSCFG_FEATURE_LANULA_SUPPORT, buf, sizeof(buf)) ) 
+                { 
+                    //1-Extender Mode 0-Gateway Mode
+                    if (strcmp(buf,"true") == 0)
                     {
-                        CcspTraceError(("%s %d - SetDataModelParameter failed on dns_enable request \n", __FUNCTION__, __LINE__));
+                        IsLANULASupportAvailable = TRUE;
                     }
                 }
-                free(datamodel_value);
+
+                if( TRUE == IsLANULASupportAvailable )
+                {
+        #endif /** _RDKB_GLOBAL_PRODUCT_REQ_ */
+                    datamodel_value = (char *) malloc(sizeof(char) * 256);
+                    if(datamodel_value != NULL)
+                    {
+                        memset(datamodel_value, 0, 256);
+                        strncpy(datamodel_value, val, sizeof(val));
+                        result = WanMgr_RdkBus_SetParamValues( PAM_COMPONENT_NAME, PAM_DBUS_PATH, "Device.DHCPv6.Server.Pool.1.X_RDKCENTRAL-COM_DNSServersEnabled", datamodel_value, ccsp_boolean, TRUE );
+                        if(result != ANSC_STATUS_SUCCESS)
+                        {
+                            CcspTraceError(("%s %d - SetDataModelParameter failed on dns_enable request \n", __FUNCTION__, __LINE__));
+                        }
+                    }
+                    free(datamodel_value);
+                }
 		#endif
             }
 #ifdef NTP_STATUS_SYNC_EVENT

--- a/source/WanManager/wanmgr_sysevents.c
+++ b/source/WanManager/wanmgr_sysevents.c
@@ -216,12 +216,17 @@ ANSC_STATUS wanmgr_set_Ipv4Sysevent(const WANMGR_IPV4_DATA* dhcp4Info, DEVICE_NE
     }
     sysevent_set(sysevent_fd, sysevent_token,name, dhcp4Info->ip, 0);
 
-#if !defined (_XB6_PRODUCT_REQ_) && !defined (_CBR2_PRODUCT_REQ_) && !defined(_PLATFORM_RASPBERRYPI_) //parodus uses cmac for xb platforms
-    // set wan mac because parodus depends on it to start.
-    if(ANSC_STATUS_SUCCESS == WanManager_get_interface_mac(dhcp4Info->ifname, ifaceMacAddress, sizeof(ifaceMacAddress)))
+#if (!defined (_XB6_PRODUCT_REQ_) && !defined (_CBR2_PRODUCT_REQ_) && !defined(_PLATFORM_RASPBERRYPI_)) || defined (_SCER11BEL_PRODUCT_REQ_) //parodus uses cmac for xb platforms
+#if defined (_SCER11BEL_PRODUCT_REQ_)
+    if( TRUE == WanMgr_Util_IsThisCurrentPartnerID("sky-uk") )
+#endif /* _SCER11BEL_PRODUCT_REQ_ */
     {
-        CcspTraceInfo(("%s %d - setting sysevent eth_wan_mac = [%s]  \n", __FUNCTION__, __LINE__, ifaceMacAddress));
-        sysevent_set(sysevent_fd, sysevent_token, SYSEVENT_ETH_WAN_MAC, ifaceMacAddress, 0);
+        // set wan mac because parodus depends on it to start.
+        if(ANSC_STATUS_SUCCESS == WanManager_get_interface_mac(dhcp4Info->ifname, ifaceMacAddress, sizeof(ifaceMacAddress)))
+        {
+            CcspTraceInfo(("%s %d - setting sysevent eth_wan_mac = [%s]  \n", __FUNCTION__, __LINE__, ifaceMacAddress));
+            sysevent_set(sysevent_fd, sysevent_token, SYSEVENT_ETH_WAN_MAC, ifaceMacAddress, 0);
+        }
     }
 #endif
 
@@ -1239,8 +1244,13 @@ void wanmgr_Ipv6Toggle (void)
 {
     char v6Toggle[BUFLEN_128] = {0};
 #if (defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_)) &&  !defined(FEATURE_RDKB_CONFIGURABLE_WAN_INTERFACE)//TODO: V6 handled in PAM
-    /*Ipv6 handled in PAM.  No Toggle Needed. */
-    return;
+#if defined (_SCER11BEL_PRODUCT_REQ_)
+    if( FALSE == WanMgr_Util_IsThisCurrentPartnerID("sky-uk") )
+#endif /* _SCER11BEL_PRODUCT_REQ_ */
+    {
+        /*Ipv6 handled in PAM.  No Toggle Needed. */
+        return;
+    }
 #endif
 
     sysevent_get(sysevent_fd, sysevent_token, SYSEVENT_IPV6_TOGGLE, v6Toggle, sizeof(v6Toggle));

--- a/source/WanManager/wanmgr_sysevents.c
+++ b/source/WanManager/wanmgr_sysevents.c
@@ -714,7 +714,6 @@ static void *WanManagerSyseventHandler(void *args)
 
                 if( 0 == syscfg_get(NULL, SYSCFG_FEATURE_LANULA_SUPPORT, buf, sizeof(buf)) ) 
                 { 
-                    //1-Extender Mode 0-Gateway Mode
                     if (strcmp(buf,"true") == 0)
                     {
                         IsLANULASupportAvailable = TRUE;
@@ -761,7 +760,6 @@ static void *WanManagerSyseventHandler(void *args)
 
                 if( 0 == syscfg_get(NULL, SYSCFG_FEATURE_LANULA_SUPPORT, buf, sizeof(buf)) ) 
                 { 
-                    //1-Extender Mode 0-Gateway Mode
                     if (strcmp(buf,"true") == 0)
                     {
                         IsLANULASupportAvailable = TRUE;

--- a/source/WanManager/wanmgr_sysevents.c
+++ b/source/WanManager/wanmgr_sysevents.c
@@ -728,13 +728,6 @@ static void *WanManagerSyseventHandler(void *args)
                 if( TRUE == IsLANULASupportAvailable )
         #endif /** _RDKB_GLOBAL_PRODUCT_REQ_ */
                 {
-                    CcspTraceError(("%s %d - Before checking\n", __FUNCTION__, __LINE__));
-                    if (WanManager_DoSystemActionWithStatus("wanmanager", "ifconfig brlan0 >> /rdklogs/logs/WANMANAGERLog.txt.0; ifconfig >> /rdklogs/logs/WANMANAGERLog.txt.0") != RETURN_OK)
-                    {
-                        CcspTraceError(("%s %d failed set command: %s\n", __FUNCTION__, __LINE__, "ifconfig brlan0"));
-                    }
-                    CcspTraceError(("%s %d - After checking\n", __FUNCTION__, __LINE__));
-
                     datamodel_value = (char *) malloc(sizeof(char) * 256);
                     if(datamodel_value != NULL)
                     {
@@ -758,17 +751,6 @@ static void *WanManagerSyseventHandler(void *args)
                     {
                         CcspTraceError(("%s %d failed set command: %s\n", __FUNCTION__, __LINE__, cmd_str));
                     }
-                    if (WanManager_DoSystemActionWithStatus("wanmanager", "ifconfig brlan0 >> /rdklogs/logs/WANMANAGERLog.txt.0; ifconfig brlan0 >> /rdklogs/logs/WANMANAGERLog.txt.1") != RETURN_OK)
-                    {
-                        CcspTraceError(("%s %d failed set command: %s\n", __FUNCTION__, __LINE__, "ifconfig brlan0"));
-                    }
-
-                    CcspTraceError(("%s %d - Before checking\n", __FUNCTION__, __LINE__));
-                    if (WanManager_DoSystemActionWithStatus("wanmanager", "ifconfig brlan0 >> /rdklogs/logs/WANMANAGERLog.txt.0; ifconfig >> /rdklogs/logs/WANMANAGERLog.txt.0") != RETURN_OK)
-                    {
-                        CcspTraceError(("%s %d failed set command: %s\n", __FUNCTION__, __LINE__, "ifconfig brlan0"));
-                    }
-                    CcspTraceError(("%s %d - After checking\n", __FUNCTION__, __LINE__));
                 }
 		#endif
             }
@@ -792,13 +774,6 @@ static void *WanManagerSyseventHandler(void *args)
                 if( TRUE == IsLANULASupportAvailable )
         #endif /** _RDKB_GLOBAL_PRODUCT_REQ_ */
                 {
-                    CcspTraceError(("%s %d - Before checking\n", __FUNCTION__, __LINE__));
-                    if (WanManager_DoSystemActionWithStatus("wanmanager", "ifconfig brlan0 >> /rdklogs/logs/WANMANAGERLog.txt.0; ifconfig >> /rdklogs/logs/WANMANAGERLog.txt.0") != RETURN_OK)
-                    {
-                        CcspTraceError(("%s %d failed set command: %s\n", __FUNCTION__, __LINE__, "ifconfig brlan0"));
-                    }
-                    CcspTraceError(("%s %d - After checking\n", __FUNCTION__, __LINE__));
-                    
                     datamodel_value = (char *) malloc(sizeof(char) * 256);
                     if(datamodel_value != NULL)
                     {

--- a/source/WanManager/wanmgr_sysevents.c
+++ b/source/WanManager/wanmgr_sysevents.c
@@ -728,6 +728,13 @@ static void *WanManagerSyseventHandler(void *args)
                 if( TRUE == IsLANULASupportAvailable )
         #endif /** _RDKB_GLOBAL_PRODUCT_REQ_ */
                 {
+                    CcspTraceError(("%s %d - Before checking\n", __FUNCTION__, __LINE__));
+                    if (WanManager_DoSystemActionWithStatus("wanmanager", "ifconfig brlan0 >> /rdklogs/logs/WANMANAGERLog.txt.0; ifconfig >> /rdklogs/logs/WANMANAGERLog.txt.0") != RETURN_OK)
+                    {
+                        CcspTraceError(("%s %d failed set command: %s\n", __FUNCTION__, __LINE__, "ifconfig brlan0"));
+                    }
+                    CcspTraceError(("%s %d - After checking\n", __FUNCTION__, __LINE__));
+
                     datamodel_value = (char *) malloc(sizeof(char) * 256);
                     if(datamodel_value != NULL)
                     {
@@ -755,6 +762,13 @@ static void *WanManagerSyseventHandler(void *args)
                     {
                         CcspTraceError(("%s %d failed set command: %s\n", __FUNCTION__, __LINE__, "ifconfig brlan0"));
                     }
+
+                    CcspTraceError(("%s %d - Before checking\n", __FUNCTION__, __LINE__));
+                    if (WanManager_DoSystemActionWithStatus("wanmanager", "ifconfig brlan0 >> /rdklogs/logs/WANMANAGERLog.txt.0; ifconfig >> /rdklogs/logs/WANMANAGERLog.txt.0") != RETURN_OK)
+                    {
+                        CcspTraceError(("%s %d failed set command: %s\n", __FUNCTION__, __LINE__, "ifconfig brlan0"));
+                    }
+                    CcspTraceError(("%s %d - After checking\n", __FUNCTION__, __LINE__));
                 }
 		#endif
             }
@@ -778,6 +792,13 @@ static void *WanManagerSyseventHandler(void *args)
                 if( TRUE == IsLANULASupportAvailable )
         #endif /** _RDKB_GLOBAL_PRODUCT_REQ_ */
                 {
+                    CcspTraceError(("%s %d - Before checking\n", __FUNCTION__, __LINE__));
+                    if (WanManager_DoSystemActionWithStatus("wanmanager", "ifconfig brlan0 >> /rdklogs/logs/WANMANAGERLog.txt.0; ifconfig >> /rdklogs/logs/WANMANAGERLog.txt.0") != RETURN_OK)
+                    {
+                        CcspTraceError(("%s %d failed set command: %s\n", __FUNCTION__, __LINE__, "ifconfig brlan0"));
+                    }
+                    CcspTraceError(("%s %d - After checking\n", __FUNCTION__, __LINE__));
+                    
                     datamodel_value = (char *) malloc(sizeof(char) * 256);
                     if(datamodel_value != NULL)
                     {

--- a/source/WanManager/wanmgr_sysevents.c
+++ b/source/WanManager/wanmgr_sysevents.c
@@ -769,8 +769,8 @@ static void *WanManagerSyseventHandler(void *args)
                 }
 
                 if( TRUE == IsLANULASupportAvailable )
-                {
         #endif /** _RDKB_GLOBAL_PRODUCT_REQ_ */
+                {
                     datamodel_value = (char *) malloc(sizeof(char) * 256);
                     if(datamodel_value != NULL)
                     {

--- a/source/WanManager/wanmgr_sysevents.h
+++ b/source/WanManager/wanmgr_sysevents.h
@@ -221,6 +221,11 @@ BRIDGE_MODE_STATUS_STOPPED,
 
 #endif
 
+#if defined(_RDKB_GLOBAL_PRODUCT_REQ_)
+/* Global Product Build Features */
+#define SYSCFG_FEATURE_LANULA_SUPPORT               "LANULASupport"
+#endif /** _RDKB_GLOBAL_PRODUCT_REQ_ */
+
 /**********************************************************************
                 FUNCTION PROTOTYPES
 **********************************************************************/

--- a/source/WanManager/wanmgr_utils.c
+++ b/source/WanManager/wanmgr_utils.c
@@ -1130,3 +1130,21 @@ int sysctl_iface_set(const char *path, const char *ifname, const char *content)
 
     return 0;
 }
+
+/** WanMgr_Util_IsThisCurrentPartnerID() */
+unsigned char WanMgr_Util_IsThisCurrentPartnerID( const char* pcPartnerID )
+{
+    if ( NULL != pcPartnerID )
+    {
+        char actmpPartnerID[64] = {0};
+
+        if( ( CCSP_SUCCESS == getPartnerId( actmpPartnerID ) ) && \
+            ( actmpPartnerID[ 0 ] != '\0' ) && \
+            ( 0 == strcmp( pcPartnerID, actmpPartnerID ) ) )
+        {
+            return TRUE;
+        }
+    }
+
+    return FALSE;
+}

--- a/source/WanManager/wanmgr_utils.h
+++ b/source/WanManager/wanmgr_utils.h
@@ -32,6 +32,7 @@
 
 
 #include "wanmgr_rdkbus_common.h"
+#include "ccsp_base_api.h"
 //#include "ipc_msg.h"
 
 
@@ -165,5 +166,6 @@ ANSC_STATUS WanMgr_RestartUpdateCfg (const char * param, int idx, char * output,
 ANSC_STATUS WanMgr_RestartUpdateCfg_Bool (const char * param, int idx, BOOL* output);
 
 int sysctl_iface_set(const char *path, const char *ifname, const char *content);
+unsigned char WanMgr_Util_IsThisCurrentPartnerID( const char* pcPartnerID );
 
 #endif /* _WANMGR_UTILS_H_ */


### PR DESCRIPTION

Reason for change:
IPv6 Handling Requirement for Sky Products are different from Comcast. Sky using IAPD , DHCPv6 prefix delegation to provide prefixes for use on the subscriber LAN as well as to get WAN IPv6 address from backend.

The implementation for this feature is under CcspPandM components so that needs to be enable for applicable products like Sky. So we need to control _RDKB_GLOBAL_PRODUCT_REQ_ common MACRO with feature applicable flags with respect to region.

Test Procedure:
1. IPv6 ULA should work for Sky but those params writable permission should be prohibited for comcast products.
2. WAN and LAN functionality should work without any issue.

Risks: Medium

Signed-off-by: Lakshminarayanan <lakshminarayanan.shenbagaraj2@sky.uk>