### PR TITLE
RDKCOM-5180 RDKBDEV-3025: WanManager trying to get default route for erouter0 main routing table

### DIFF
--- a/source/WanManager/wanmgr_net_utils.c
+++ b/source/WanManager/wanmgr_net_utils.c
@@ -2493,11 +2493,27 @@ bool IsDefaultRoutePresent(char *IfaceName, bool IsV4)
 
     if (IsV4)
     {
-        fp = v_secure_popen("r","ip -4 route show default | grep default | awk '{print $5}'");
+        // For erouter0 we want take default route from erouter table
+        if (strcmp(IfaceName, "erouter0") == 0)
+        {
+            fp = v_secure_popen("r","ip -4 route list table erouter | grep default | awk '{print $5}'");
+        }
+        else
+        {
+            fp = v_secure_popen("r","ip -4 route show default | grep default | awk '{print $5}'");
+        }
     }
     else
     {
-        fp = v_secure_popen("r","ip -6 route show default | grep default | awk '{print $5}'");
+        // For erouter0 we want take default route from erouter table
+        if (strcmp(IfaceName, "erouter0") == 0)
+        {
+            fp = v_secure_popen("r","ip -6 route list table erouter | grep default | awk '{print $5}'");
+        }
+        else
+        {
+            fp = v_secure_popen("r","ip -6 route show default | grep default | awk '{print $5}'");
+        }
     }
     if (fp)
     {


### PR DESCRIPTION
RDKBDEV-3025: WanManager trying to get default route for erouter0 main routing table

Reason for change: WanManager trying to get default route from the default routing table instead of erouter routring table where default route added.
Test Procedure: Read wanmanager log

Risks: Low
Priority: P4