### PR TITLE
RDKBNETWOR-21 : Integrating CcspMisc changes to DHCPManager

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -101,6 +101,15 @@ AC_ARG_ENABLE([wanunificationsupport],
              [echo "mapt unification is disabled"])
 AM_CONDITIONAL(WAN_UNIFICATION_ENABLED, test "x$WAN_UNIFICATION_SUPPORT_ENABLED" = xtrue)
 
+AC_ARG_ENABLE([dhcp_manager],
+[  --enable-dhcp_manager    Turn on dhcp_manager ],
+[case "${enableval}" in
+yes) DHCP_MANAGER_ENABLE=true ;;
+no)  DHCP_MANAGER_ENABLE=false ;;
+*) AC_MSG_ERROR([bad value ${enableval} for --enable-dhcp_manager]) ;;
+esac],[DHCP_MANAGER_ENABLE=false])
+AM_CONDITIONAL([DHCP_MANAGER_ENABLE], [test x$DHCP_MANAGER_ENABLE = xtrue])
+
 dnl Checks for header files.
 AC_CHECK_HEADERS([limits.h memory.h stdlib.h string.h sys/socket.h unistd.h])
 

--- a/source/WanManager/Makefile.am
+++ b/source/WanManager/Makefile.am
@@ -31,8 +31,13 @@ wanmanager_CPPFLAGS = -I$(top_srcdir)/source/TR-181/middle_layer_src \
 wanmanager_CFLAGS = -DFEATURE_SUPPORT_RDKLOG $(DBUS_CFLAGS) $(SYSTEMD_CFLAGS)
 wanmanager_CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
 wanmanager_SOURCES = wanmgr_webconfig_apis.c wanmgr_webconfig.c wanmgr_main.c  wanmgr_ssp_action.c wanmgr_ssp_messagebus_interface.c wanmgr_core.c wanmgr_controller.c wanmgr_data.c wanmgr_sysevents.c wanmgr_interface_sm.c wanmgr_utils.c wanmgr_net_utils.c wanmgr_dhcpv4_apis.c wanmgr_dhcpv6_apis.c wanmgr_ipc.c wanmgr_dhcpv4_internal.c wanmgr_dhcpv6_internal.c wanmgr_policy_autowan_impl.c wanmgr_policy_auto_impl.c dm_pack_datamodel.c wanmgr_wan_failover.c wanmgr_policy_parallel_scan_impl.c wanmgr_dhcp_legacy_apis.c
-wanmanager_LDADD = $(wanmanager_DEPENDENCIES) -lccsp_common -lrdkloggers $(DBUS_LIBS) $(SYSTEMD_LDFLAGS) -lhal_platform -lapi_dhcpv4c -lnanomsg -lwebconfig_framework -lmsgpackc -ldhcp_client_utils -lprivilege -lrbus -lsecure_wrapper
+wanmanager_LDADD = $(wanmanager_DEPENDENCIES) -lccsp_common -lrdkloggers $(DBUS_LIBS) $(SYSTEMD_LDFLAGS) -lhal_platform -lapi_dhcpv4c -lnanomsg -lwebconfig_framework -lmsgpackc -lprivilege -lrbus -lsecure_wrapper
 
+if DHCP_MANAGER_ENABLE
+wanmanager_LDADD += -lCcspDhcpMgr_Dhcpv6Client -lCcspDhcpMgr_Dhcpv4Client
+else
+wanmanager_LDADD += -ldhcp_client_utils
+endif
 
 if WAN_UNIFICATION_ENABLED
 wanmanager_SOURCES +=  DHCPv6cMsgHandler/dhcpv6c_msg_apis.c


### PR DESCRIPTION
Reason for change: Integrating CcspMisc changes to DHCPManager required for Wanmanager Integration Test Procedure: DHCPManager should run without any new regressions Risks: Low
Priority: Minor
Signed-off-by:BudimeVigneshwar_Prasad@comcast.com