### PR TITLE
SHARMAN-3234 : [HUB6 Layered Image] : WanManager is crashing continuo…

### DIFF
--- a/source/WanManager/DHCPv6cMsgHandler/dhcpv6c_msg_apis.c
+++ b/source/WanManager/DHCPv6cMsgHandler/dhcpv6c_msg_apis.c
@@ -54,6 +54,7 @@
 #include "secure_wrapper.h"
 
 #include "wanmgr_dml.h"
+#include "wanmgr_data.h"
 #include "dhcpv6c_msg_apis.h"
 
 /*


### PR DESCRIPTION
…usly and no WAN

Reason for change: Fixing  sign extension problem during the return of WanMgr_GetVIfByName_VISM_running_locked() in 64 bit builds.

Test Procedure:
No WanManager crash should be observed in 64bit builds.

Risks: none
Priority: P1