### PR TITLE
XER10-823 : Support VLAN Marking for Sky XER10 variant.

### DIFF
--- a/source/TR-181/include/dmsb_tr181_psm_definitions.h
+++ b/source/TR-181/include/dmsb_tr181_psm_definitions.h
@@ -33,6 +33,7 @@
 #define PSM_WANMANAGER_IPV6EUI64FORMAT_SUPPPORT             "dmsb.wanmanager.IPv6EUI64FormatSupport"
 #define PSM_WANMANAGER_CONFIGUREWANIPV6ON_LANBRIDGE_SUPPPORT  "dmsb.wanmanager.ConfigureWANIPv6OnLANBridgeSupport"
 #define PSM_WANMANAGER_USEWANMAC_FOR_MGMT_SERVICES            "dmsb.wanmanager.UseWANMACForManagementServices"
+#define PSM_WANMANAGER_INTERFACE_VLAN_MARKING_SUPPORT       "dmsb.wanmanager.InterfaceVLANMarkingSupport"
 
 #define PSM_WANMANAGER_GROUP_COUNT                          "dmsb.wanmanager.group.Count"
 #define PSM_WANMANAGER_GROUP_PERSIST_SELECTED_IFACE         "dmsb.wanmanager.group.%d.PersistSelectedInterface"

--- a/source/TR-181/include/wanmgr_dml.h
+++ b/source/TR-181/include/wanmgr_dml.h
@@ -590,7 +590,8 @@ typedef struct _DML_WANMGR_CONFIG_
     BOOLEAN BackupWanDnsSupport;    
     BOOLEAN IPv6EUI64FormatSupport;
     BOOLEAN ConfigureWANIPv6OnLANBridgeSupport;
-    BOOLEAN UseWANMACForManagementServices;            
+    BOOLEAN UseWANMACForManagementServices;
+    BOOLEAN InterfaceVLANMarkingSupport;            
 } DML_WANMGR_CONFIG;
 
 //WAN CONFIG

--- a/source/TR-181/middle_layer_src/wanmgr_rdkbus_apis.c
+++ b/source/TR-181/middle_layer_src/wanmgr_rdkbus_apis.c
@@ -719,7 +719,7 @@ DmlWanDeletePSMRecordValue
 
 #ifdef FEATURE_802_1P_COS_MARKING
 
-#if defined(_HUB4_PRODUCT_REQ_) || defined(_SCER11BEL_PRODUCT_REQ_)
+#if defined(_HUB4_PRODUCT_REQ_) || defined(_RDKB_GLOBAL_PRODUCT_REQ_)
 static void AddSkbMarkingToConfFile(UINT data_skb_mark)
 {
    FILE * fp = fopen(DATA_SKB_MARKING_LOCATION, "w+");
@@ -962,7 +962,7 @@ ANSC_STATUS WanMgr_WanIfaceMarkingInit ()
                         CcspTraceInfo(("%s - Name[%s] Data[%s,%u,%u,%d]\n", __FUNCTION__, acTmpMarkingData, p_Marking->Alias, p_Marking->SKBPort, p_Marking->SKBMark, p_Marking->EthernetPriorityMark));
                             
                             Marking_UpdateInitValue(pWanIfaceCtrl->pIface,ulIfInstanceNumber-1,ulInstanceNumber,p_Marking);
-#if defined(_HUB4_PRODUCT_REQ_) || defined(_SCER11BEL_PRODUCT_REQ_)
+#if defined(_HUB4_PRODUCT_REQ_) || defined(_RDKB_GLOBAL_PRODUCT_REQ_)
                             /* Adding skb mark to config file if alis is 'DATA', so that udhcpc could use it to mark dhcp packets */
                             if(0 == strncmp(p_Marking->Alias, "DATA", 4))
                             {

--- a/source/TR-181/middle_layer_src/wanmgr_rdkbus_apis.c
+++ b/source/TR-181/middle_layer_src/wanmgr_rdkbus_apis.c
@@ -1045,7 +1045,7 @@ DmlCheckAndProceedMarkingOperations
 
     if( NULL != pWanConfigData )
     {
-        UseWANMACForManagementServices = pWanConfigData->data.InterfaceVLANMarkingSupport;
+        InterfaceVLANMarkingSupport = pWanConfigData->data.InterfaceVLANMarkingSupport;
         WanMgrDml_GetConfigData_release(pWanConfigData);
     }
 

--- a/source/TR-181/middle_layer_src/wanmgr_rdkbus_apis.c
+++ b/source/TR-181/middle_layer_src/wanmgr_rdkbus_apis.c
@@ -800,7 +800,7 @@ ANSC_STATUS WanMgr_WanIfaceMarkingInit ()
     }
 
 #if defined(_RDKB_GLOBAL_PRODUCT_REQ_)
-    if( FALSE == gWanMgrDataBase.Config.InterfaceVLANMarkingSupport )
+    if( FALSE == gWanMgrDataBase.Config.Data.InterfaceVLANMarkingSupport )
     {
         CcspTraceInfo(("%s %d - Interface VLAN Marking Not Supported\n", __FUNCTION__, __LINE__));
         return ANSC_STATUS_SUCCESS;  
@@ -1049,7 +1049,7 @@ DmlCheckAndProceedMarkingOperations
         WanMgrDml_GetConfigData_release(pWanConfigData);
     }
 
-    if( FALSE == gWanMgrDataBase.Config.InterfaceVLANMarkingSupport )
+    if( FALSE == InterfaceVLANMarkingSupport )
     {
         CcspTraceError(("%s %d - Interface VLAN Marking Not Supported. So ignoring %d request\n", __FUNCTION__, __LINE__, enMarkingOp));
         return ANSC_STATUS_FAILURE;  

--- a/source/TR-181/middle_layer_src/wanmgr_rdkbus_apis.c
+++ b/source/TR-181/middle_layer_src/wanmgr_rdkbus_apis.c
@@ -800,7 +800,7 @@ ANSC_STATUS WanMgr_WanIfaceMarkingInit ()
     }
 
 #if defined(_RDKB_GLOBAL_PRODUCT_REQ_)
-    if( FALSE == gWanMgrDataBase.Config.Data.InterfaceVLANMarkingSupport )
+    if( FALSE == gWanMgrDataBase.Config.data.InterfaceVLANMarkingSupport )
     {
         CcspTraceInfo(("%s %d - Interface VLAN Marking Not Supported\n", __FUNCTION__, __LINE__));
         return ANSC_STATUS_SUCCESS;  

--- a/source/WanManager/wanmgr_data.c
+++ b/source/WanManager/wanmgr_data.c
@@ -72,7 +72,8 @@ void WanMgr_SetConfigData_Default(DML_WANMGR_CONFIG* pWanDmlConfig)
         pWanDmlConfig->BackupWanDnsSupport = TRUE;    
         pWanDmlConfig->IPv6EUI64FormatSupport = TRUE;
         pWanDmlConfig->ConfigureWANIPv6OnLANBridgeSupport = FALSE;
-        pWanDmlConfig->UseWANMACForManagementServices = FALSE;  
+        pWanDmlConfig->UseWANMACForManagementServices = FALSE;
+        pWanDmlConfig->InterfaceVLANMarkingSupport = FALSE;   
 
         /*In Modem/Extender Mode, CurrentActiveInterface should be always Mesh Interface Name*/
 #if defined (RDKB_EXTENDER_ENABLED)


### PR DESCRIPTION
Reason for change:
Supported VLAN Marking operations for Sky XER10 variant.

Test Procedure:
1. WAN Manager functionality should work without any issue
2. VLAN Marking entries should be present as part of DML, Device.X_RDK_WanManager.Interface.<x>.Marking.
3. Voice Marking should work without any issue

Risks: Low

Signed-off-by: Lakshminarayanan <lakshminarayanan.shenbagaraj2@sky.uk>