### PR TITLE
RDKB-58019 : Adding version log.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -44,10 +44,10 @@ m4_ifdef([AM_SILENT_RULES],[AM_SILENT_RULES([yes])],
   [AM_DEFAULT_VERBOSITY=1
    AC_SUBST(AM_DEFAULT_VERBOSITY)])
 
-m4_define([GIT_VERSION],
+m4_define([GITVERSION],
   m4_esyscmd_s([git describe --tags --always --dirty 2>/dev/null || echo "undefined"])
 )
-AC_SUBST([GIT_VERSION], [GIT_VERSION])
+AC_SUBST([GIT_VERSION], [GITVERSION])
 
 
 dnl **********************************


### PR DESCRIPTION
Reason for change:  Adding version log using "git describe --tags --always --dirty" command Example :
RC2.7.0a-1-g5aa0583-dirty
Tag: RC2.7.0a (Most recent tag)
Number of Commits Ahead: -1 (1 commit after the tag) Commit Hash: g5aa0583 ( "5aa0583" Hash of the current commit) Uncommitted Changes: -dirty (Changes not yet committed)

Test Procedure:
Version log should be present.

Priority: P1
Risks: none