### PR TITLE
RDKB-58146 : [Field][INC] T-PW7 and T-PW8 "lease time remaining" valu…

### DIFF
--- a/source/WanManager/wanmgr_dhcpv4_apis.c
+++ b/source/WanManager/wanmgr_dhcpv4_apis.c
@@ -790,7 +790,14 @@ WanMgr_DmlDhcpcGetInfo
         pInfo->DHCPServer.Value = inet_addr(p_VirtIf->IP.Ipv4Data.dhcpServerId);
 	pInfo->DHCPStatus = ((strcmp(p_VirtIf->IP.Ipv4Data.dhcpState, DHCP_STATE_BOUND) == 0) || 
                        (strcmp(p_VirtIf->IP.Ipv4Data.dhcpState, DHCP_STATE_RENEW) == 0)) ? DML_DHCPC_STATUS_Bound : DML_DHCPC_STATUS_Init;
-        pInfo->LeaseTimeRemaining  = (p_VirtIf->IP.Ipv4Data.leaseReceivedTime + p_VirtIf->IP.Ipv4Data.leaseTime) - WanManager_getUpTime();
+        if (pInfo->DHCPStatus == DML_DHCPC_STATUS_Bound)
+        {
+            pInfo->LeaseTimeRemaining  = (p_VirtIf->IP.Ipv4Data.leaseReceivedTime + p_VirtIf->IP.Ipv4Data.leaseTime) - WanManager_getUpTime();
+        }
+        else 
+        {
+            pInfo->LeaseTimeRemaining = 0;
+        }    
         WanMgrDml_GetIfaceData_release(NULL);
     }
 
@@ -833,7 +840,14 @@ WanMgr_DmlDhcpcGetInfo
     }
         for(i=0; i< pInfo->NumDnsServers;i++)
                 pInfo->DNSServers[i].Value = ad.addrs[i];
+    if (pInfo->DHCPStatus == DML_DHCPC_STATUS_Bound)
+    {
         dhcpv4c_get_ert_remain_lease_time((unsigned int*)&pInfo->LeaseTimeRemaining);
+    }
+    else 
+    {
+        pInfo->LeaseTimeRemaining = 0;
+    }   
         dhcpv4c_get_ert_dhcp_svr((unsigned int*)&pInfo->DHCPServer);
 
     return ANSC_STATUS_SUCCESS;


### PR DESCRIPTION
…e is negative in "group_adv_cpe_information" Bizapi group

Reason for change: Dhcpv4 lease time Remaining should be zero for MAP-T
Test Procedure: Check the value of dhcpv4 lease time remaining in MAPT
Risks: Low
Priority: P1
Signed-off-by: Sunu_Sunil@comcast.com