### PR TITLE
RDKCOM-5227 RDKBDEV-3093 : Clearing capabilities leakage in RdkWanManager

### DIFF
--- a/source/WanManager/wanmgr_main.c
+++ b/source/WanManager/wanmgr_main.c
@@ -295,6 +295,7 @@ int main(int argc, char* argv[])
         drop_root_caps(&appcaps);
         update_process_caps(&appcaps);
         read_capability(&appcaps);
+        clear_caps(&appcaps);
     }
 
     for (idx = 1; idx < argc; idx++)


### PR DESCRIPTION
RDKBDEV-3093 : Clearing capabilities leakage in RdkWanManager

Reason for change: possibly lost: 194 bytes in 1 blocks caused by reading capabilities and not clearing after.
Test Procedure: run valgind with this module
Risks: None

Signed-off-by: Marek Mizinak <Marek.Miziniak@cognizant.com>