### PR TITLE
XER10-924 : Writing BaseInterface path to PSM when it is set.

### DIFF
--- a/source/TR-181/middle_layer_src/wanmgr_dml_iface_v2_apis.c
+++ b/source/TR-181/middle_layer_src/wanmgr_dml_iface_v2_apis.c
@@ -774,6 +774,24 @@ BOOL WanIf_Validate(ANSC_HANDLE hInsContext, char* pReturnParamName, ULONG* puLe
 **********************************************************************/
 ULONG WanIf_Commit(ANSC_HANDLE hInsContext)
 {
+    ANSC_STATUS result;
+    WanMgr_Iface_Data_t* pIfaceDmlEntry = (WanMgr_Iface_Data_t*) hInsContext;
+    if(pIfaceDmlEntry != NULL)
+    {
+        WanMgr_Iface_Data_t* pWanDmlIfaceData = WanMgr_GetIfaceData_locked(pIfaceDmlEntry->data.uiIfaceIdx);
+        if(pWanDmlIfaceData != NULL)
+        {
+            DML_WAN_IFACE* pWanDmlIface = &(pWanDmlIfaceData->data);
+
+            result = DmlSetWanIfCfg( pWanDmlIface->uiInstanceNumber, pWanDmlIface );
+            if(result != ANSC_STATUS_SUCCESS)
+            {
+                CcspTraceError(("%s: Failed to write PSM \n", __FUNCTION__));
+            }
+            WanMgrDml_GetIfaceData_release(pWanDmlIfaceData);
+        }
+    }
+
     return 0;
 }
 


### PR DESCRIPTION
Reason for change:
Writing BaseInterface path to PSM when it is set.

Test Procedure:
Updated in Jira.

Risks: none
Priority: P1