### PR TITLE
LTE-2585 : Parodus connectivity lost because ActiveInterface_split is "br-home,br-home".

### DIFF
--- a/source/TR-181/middle_layer_src/wanmgr_rdkbus_apis.c
+++ b/source/TR-181/middle_layer_src/wanmgr_rdkbus_apis.c
@@ -1890,29 +1890,27 @@ ANSC_STATUS Update_Interface_Status()
                 }else
                     snprintf(newIface->ActiveStatus, sizeof(newIface->ActiveStatus), "%s,0", pWanIfaceData->DisplayName);
 
-                if(devMode  == GATEWAY_MODE)
+                /*
+                 * In Gateway Mode, CurrentActiveInterface should be an actual virtual Interface Name
+                 * In Modem/Extender Mode, CurrentActiveInterface should be always Mesh Interface Name
+                 */
+
+                if(pWanIfaceData->Selection.Status == WAN_IFACE_ACTIVE)
                 {
-                    if(pWanIfaceData->Selection.Status == WAN_IFACE_ACTIVE)
-                    {
-                        snprintf(newIface->CurrentActive, sizeof(newIface->CurrentActive), "%s", p_VirtIf->Name);
+                    snprintf(newIface->CurrentActive, sizeof(newIface->CurrentActive), "%s", (devMode == GATEWAY_MODE) ? p_VirtIf->Name : MESH_IFNAME);
 #ifdef RBUS_BUILD_FLAG_ENABLE
-                        snprintf(CurrentWanStatus,sizeof(CurrentWanStatus), "%s", (p_VirtIf->Status == WAN_IFACE_STATUS_UP)?"Up":"Down");
+                    snprintf(CurrentWanStatus,sizeof(CurrentWanStatus), "%s", (p_VirtIf->Status == WAN_IFACE_STATUS_UP)?"Up":"Down");
 #endif
 #if defined(FEATURE_RDKB_CONFIGURABLE_WAN_INTERFACE)
-                        /* Update Only for Gateway mode. Wan IP Interface entry not added in PAM for MODEM_MODE */
-                        WanMgr_RdkBus_setWanIpInterfaceData(p_VirtIf);
+                    /* Update Only for Gateway mode. Wan IP Interface entry not added in PAM for MODEM_MODE */
+                    WanMgr_RdkBus_setWanIpInterfaceData(p_VirtIf);
 #endif
-                    }
-                    else if(pWanIfaceData->Selection.Status == WAN_IFACE_SELECTED)
-                    {
-                        snprintf(newIface->CurrentStandby, sizeof(newIface->CurrentStandby), "%s", p_VirtIf->Name);
-                    }
                 }
-                else // MODEM_MODE
+                else if(pWanIfaceData->Selection.Status == WAN_IFACE_SELECTED)
                 {
-                    /*In Modem/Extender Mode, CurrentActiveInterface should be always Mesh Interface Name*/
-                    strncpy(newIface->CurrentActive, MESH_IFNAME, sizeof(MESH_IFNAME));
+                    snprintf(newIface->CurrentStandby, sizeof(newIface->CurrentStandby), "%s", p_VirtIf->Name);
                 }
+
                 /* Sort the link list based on priority */
                 SortedInsert(&head, newIface);
             }

--- a/source/TR-181/middle_layer_src/wanmgr_rdkbus_apis.c
+++ b/source/TR-181/middle_layer_src/wanmgr_rdkbus_apis.c
@@ -1902,8 +1902,11 @@ ANSC_STATUS Update_Interface_Status()
                     snprintf(CurrentWanStatus,sizeof(CurrentWanStatus), "%s", (p_VirtIf->Status == WAN_IFACE_STATUS_UP)?"Up":"Down");
 #endif
 #if defined(FEATURE_RDKB_CONFIGURABLE_WAN_INTERFACE)
-                    /* Update Only for Gateway mode. Wan IP Interface entry not added in PAM for MODEM_MODE */
-                    WanMgr_RdkBus_setWanIpInterfaceData(p_VirtIf);
+                    if (devMode == GATEWAY_MODE)
+                    {
+                        /* Update Only for Gateway mode. Wan IP Interface entry not added in PAM for MODEM_MODE */
+                        WanMgr_RdkBus_setWanIpInterfaceData(p_VirtIf);
+                    }
 #endif
                 }
                 else if(pWanIfaceData->Selection.Status == WAN_IFACE_SELECTED)

--- a/source/TR-181/middle_layer_src/wanmgr_rdkbus_apis.c
+++ b/source/TR-181/middle_layer_src/wanmgr_rdkbus_apis.c
@@ -1890,29 +1890,27 @@ ANSC_STATUS Update_Interface_Status()
                 }else
                     snprintf(newIface->ActiveStatus, sizeof(newIface->ActiveStatus), "%s,0", pWanIfaceData->DisplayName);
 
-                if(devMode  == GATEWAY_MODE)
+                /*
+                 * In Gateway Mode, CurrentActiveInterface should be an actual virtual Interface Name
+                 * In Modem/Extender Mode, CurrentActiveInterface should be always Mesh Interface Name
+                 */
+
+                if(pWanIfaceData->Selection.Status == WAN_IFACE_ACTIVE)
                 {
-                    if(pWanIfaceData->Selection.Status == WAN_IFACE_ACTIVE)
-                    {
-                        snprintf(newIface->CurrentActive, sizeof(newIface->CurrentActive), "%s", p_VirtIf->Name);
+                    snprintf(newIface->CurrentActive, sizeof(newIface->CurrentActive), "%s", (devMode == GATEWAY_MODE) ? (p_VirtIf->Name : MESH_IFNAME ));
 #ifdef RBUS_BUILD_FLAG_ENABLE
-                        snprintf(CurrentWanStatus,sizeof(CurrentWanStatus), "%s", (p_VirtIf->Status == WAN_IFACE_STATUS_UP)?"Up":"Down");
+                    snprintf(CurrentWanStatus,sizeof(CurrentWanStatus), "%s", (p_VirtIf->Status == WAN_IFACE_STATUS_UP)?"Up":"Down");
 #endif
 #if defined(FEATURE_RDKB_CONFIGURABLE_WAN_INTERFACE)
-                        /* Update Only for Gateway mode. Wan IP Interface entry not added in PAM for MODEM_MODE */
-                        WanMgr_RdkBus_setWanIpInterfaceData(p_VirtIf);
+                    /* Update Only for Gateway mode. Wan IP Interface entry not added in PAM for MODEM_MODE */
+                    WanMgr_RdkBus_setWanIpInterfaceData(p_VirtIf);
 #endif
-                    }
-                    else if(pWanIfaceData->Selection.Status == WAN_IFACE_SELECTED)
-                    {
-                        snprintf(newIface->CurrentStandby, sizeof(newIface->CurrentStandby), "%s", p_VirtIf->Name);
-                    }
                 }
-                else // MODEM_MODE
+                else if(pWanIfaceData->Selection.Status == WAN_IFACE_SELECTED)
                 {
-                    /*In Modem/Extender Mode, CurrentActiveInterface should be always Mesh Interface Name*/
-                    strncpy(newIface->CurrentActive, MESH_IFNAME, sizeof(MESH_IFNAME));
+                    snprintf(newIface->CurrentStandby, sizeof(newIface->CurrentStandby), "%s", p_VirtIf->Name);
                 }
+  
                 /* Sort the link list based on priority */
                 SortedInsert(&head, newIface);
             }

--- a/source/TR-181/middle_layer_src/wanmgr_rdkbus_apis.c
+++ b/source/TR-181/middle_layer_src/wanmgr_rdkbus_apis.c
@@ -1890,27 +1890,29 @@ ANSC_STATUS Update_Interface_Status()
                 }else
                     snprintf(newIface->ActiveStatus, sizeof(newIface->ActiveStatus), "%s,0", pWanIfaceData->DisplayName);
 
-                /*
-                 * In Gateway Mode, CurrentActiveInterface should be an actual virtual Interface Name
-                 * In Modem/Extender Mode, CurrentActiveInterface should be always Mesh Interface Name
-                 */
-
-                if(pWanIfaceData->Selection.Status == WAN_IFACE_ACTIVE)
+                if(devMode  == GATEWAY_MODE)
                 {
-                    snprintf(newIface->CurrentActive, sizeof(newIface->CurrentActive), "%s", (devMode == GATEWAY_MODE) ? p_VirtIf->Name : MESH_IFNAME );
+                    if(pWanIfaceData->Selection.Status == WAN_IFACE_ACTIVE)
+                    {
+                        snprintf(newIface->CurrentActive, sizeof(newIface->CurrentActive), "%s", p_VirtIf->Name);
 #ifdef RBUS_BUILD_FLAG_ENABLE
-                    snprintf(CurrentWanStatus,sizeof(CurrentWanStatus), "%s", (p_VirtIf->Status == WAN_IFACE_STATUS_UP)?"Up":"Down");
+                        snprintf(CurrentWanStatus,sizeof(CurrentWanStatus), "%s", (p_VirtIf->Status == WAN_IFACE_STATUS_UP)?"Up":"Down");
 #endif
 #if defined(FEATURE_RDKB_CONFIGURABLE_WAN_INTERFACE)
-                    /* Update Only for Gateway mode. Wan IP Interface entry not added in PAM for MODEM_MODE */
-                    WanMgr_RdkBus_setWanIpInterfaceData(p_VirtIf);
+                        /* Update Only for Gateway mode. Wan IP Interface entry not added in PAM for MODEM_MODE */
+                        WanMgr_RdkBus_setWanIpInterfaceData(p_VirtIf);
 #endif
+                    }
+                    else if(pWanIfaceData->Selection.Status == WAN_IFACE_SELECTED)
+                    {
+                        snprintf(newIface->CurrentStandby, sizeof(newIface->CurrentStandby), "%s", p_VirtIf->Name);
+                    }
                 }
-                else if(pWanIfaceData->Selection.Status == WAN_IFACE_SELECTED)
+                else // MODEM_MODE
                 {
-                    snprintf(newIface->CurrentStandby, sizeof(newIface->CurrentStandby), "%s", p_VirtIf->Name);
+                    /*In Modem/Extender Mode, CurrentActiveInterface should be always Mesh Interface Name*/
+                    strncpy(newIface->CurrentActive, MESH_IFNAME, sizeof(MESH_IFNAME));
                 }
-  
                 /* Sort the link list based on priority */
                 SortedInsert(&head, newIface);
             }

--- a/source/TR-181/middle_layer_src/wanmgr_rdkbus_apis.c
+++ b/source/TR-181/middle_layer_src/wanmgr_rdkbus_apis.c
@@ -1897,7 +1897,7 @@ ANSC_STATUS Update_Interface_Status()
 
                 if(pWanIfaceData->Selection.Status == WAN_IFACE_ACTIVE)
                 {
-                    snprintf(newIface->CurrentActive, sizeof(newIface->CurrentActive), "%s", (devMode == GATEWAY_MODE) ? (p_VirtIf->Name : MESH_IFNAME ));
+                    snprintf(newIface->CurrentActive, sizeof(newIface->CurrentActive), "%s", (devMode == GATEWAY_MODE) ? p_VirtIf->Name : MESH_IFNAME );
 #ifdef RBUS_BUILD_FLAG_ENABLE
                     snprintf(CurrentWanStatus,sizeof(CurrentWanStatus), "%s", (p_VirtIf->Status == WAN_IFACE_STATUS_UP)?"Up":"Down");
 #endif

--- a/source/WanManager/wanmgr_interface_sm.c
+++ b/source/WanManager/wanmgr_interface_sm.c
@@ -2780,6 +2780,7 @@ static eWanState_t wan_transition_mapt_up(WanMgr_IfaceSM_Controller_t* pWanIface
     }
 
     sysevent_set(sysevent_fd, sysevent_token, SYSEVENT_FIREWALL_RESTART, NULL, 0);
+    wanmgr_services_restart();
 
     CcspTraceInfo(("%s %d - Interface '%s' - TRANSITION WAN_STATE_MAPT_ACTIVE\n", __FUNCTION__, __LINE__, pInterface->Name));
     return WAN_STATE_MAPT_ACTIVE;

--- a/source/WanManager/wanmgr_interface_sm.c
+++ b/source/WanManager/wanmgr_interface_sm.c
@@ -2780,7 +2780,6 @@ static eWanState_t wan_transition_mapt_up(WanMgr_IfaceSM_Controller_t* pWanIface
     }
 
     sysevent_set(sysevent_fd, sysevent_token, SYSEVENT_FIREWALL_RESTART, NULL, 0);
-    wanmgr_services_restart();
 
     CcspTraceInfo(("%s %d - Interface '%s' - TRANSITION WAN_STATE_MAPT_ACTIVE\n", __FUNCTION__, __LINE__, pInterface->Name));
     return WAN_STATE_MAPT_ACTIVE;


### PR DESCRIPTION

Reason for change:
1. When XLE detected remote device that will be added as part of WAN Interface list and has been selected because of device is in Extender Mode.
2. During this time when we update interface active status CurrentActive interface name has been updated as Mesh interface(br-home). The logic needs to be tuned when updating active interface status in WANManager during XLE switching often between GFO/WFO use case.

Test Procedure:
1. WANManager functionality should work without any issue
2. Parodus should work without any issue

Risks: Medium

Signed-off-by: LakshminarayananShenbagaraj <lakshminarayanan.shenbagaraj2@sky.uk>