### PR TITLE
XER10-1089 : Reverse SSH is not working with PROD builds in MAP-T Line in US.

### DIFF
--- a/source/WanManager/wanmgr_interface_sm.c
+++ b/source/WanManager/wanmgr_interface_sm.c
@@ -2790,6 +2790,7 @@ static eWanState_t wan_transition_mapt_up(WanMgr_IfaceSM_Controller_t* pWanIface
     }
 
     sysevent_set(sysevent_fd, sysevent_token, SYSEVENT_FIREWALL_RESTART, NULL, 0);
+    wanmgr_services_restart();
 
     CcspTraceInfo(("%s %d - Interface '%s' - TRANSITION WAN_STATE_MAPT_ACTIVE\n", __FUNCTION__, __LINE__, pInterface->Name));
     return WAN_STATE_MAPT_ACTIVE;

--- a/source/WanManager/wanmgr_sysevents.c
+++ b/source/WanManager/wanmgr_sysevents.c
@@ -1386,6 +1386,15 @@ static ANSC_STATUS wanmgr_snmpv3_restart()
 
 ANSC_STATUS wanmgr_services_restart()
 {
+    /** 
+     * Below WAN services will be refreshed during below use cases
+     * 1. WAN refresh
+     * 2. MAP-T to DualStack migration and vice versa
+     * 
+     * We need to ensure below WAN services restart may affect slow service distruption which were already 
+     * in progress. Like snmpv3 query may happen from outside of CPE and may reconnect,
+     * Someone trying to connect CPE via reversessh and it may delay or reconnect
+     */
     wanmgr_sshd_restart();
 #ifdef SNMPV3_ENABLED
     wanmgr_snmpv3_restart();


### PR DESCRIPTION

Reason for change:
SSH service has been not refreshed after MAP-T active during boot-up to avoid this issue.

Test Procedure:
1. Reversessh should work without any issue.
2. WANManager functionality should work without any issue.

Risks: Low

Signed-off-by: LakshminarayananShenbagaraj <lakshminarayanan.shenbagaraj2@sky.uk>