### PR TITLE
RDKB-58911 : Telemetry log when the DNS is changed.

### DIFF
--- a/source/TR-181/middle_layer_src/wanmgr_rdkbus_apis.c
+++ b/source/TR-181/middle_layer_src/wanmgr_rdkbus_apis.c
@@ -1988,6 +1988,10 @@ ANSC_STATUS Update_Interface_Status()
 #ifdef RBUS_BUILD_FLAG_ENABLE
                 publishCurrentActiveDNS = TRUE;
 #endif
+                CcspTraceInfo(("%s %d - SYS_INFO_DNS_updated - old : [%s] new : [%s]\n",__FUNCTION__,__LINE__,prevCurrentActiveDNS,CurrentActiveDNS));
+#ifdef ENABLE_FEATURE_TELEMETRY2_0
+                t2_event_d("SYS_INFO_DNS_updated", 1);
+#endif
             }
         }
 

--- a/source/WanManager/wanmgr_interface_sm.c
+++ b/source/WanManager/wanmgr_interface_sm.c
@@ -944,6 +944,16 @@ int wan_updateDNS(WanMgr_IfaceSM_Controller_t* pWanIfaceCtrl, BOOL addIPv4, BOOL
 
     if(resolv_conf_changed)
     {
+#if (defined (_XB6_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_))
+        //TODO: this is a workaround for the devices using the primary DNS for the backup interfaces. CurrentActiveDNS may not have the right value. 
+        WanMgr_Config_Data_t*   pWanConfigData = WanMgr_GetConfigData_locked();
+        if (pWanConfigData != NULL)
+        {
+            DML_WANMGR_CONFIG* pWanDmlData = &(pWanConfigData->data);
+            memset(pWanDmlData->CurrentActiveDNS, 0, sizeof(pWanDmlData->CurrentActiveDNS));
+            WanMgrDml_GetConfigData_release(pWanConfigData);
+        }
+#endif
         Update_Interface_Status();
     }
 


### PR DESCRIPTION
Reason for change:
Telemetry log when the DNS is changed.

Test Procedure:
Updated in Jira.

Risks: none
Priority: P1