### PR TITLE
RDKB-58931: Removing RFC control for non-root processes

### DIFF
--- a/source/WanManager/wanmgr_main.c
+++ b/source/WanManager/wanmgr_main.c
@@ -284,20 +284,12 @@ int main(int argc, char* argv[])
     char *subSys            = NULL;
     DmErr_t    err;
 
-    bool blocklist_ret = false;
-    blocklist_ret = isBlocklisted();
-    if(blocklist_ret)
-    {
-        CcspTraceInfo(("NonRoot feature is disabled\n"));
-    }
-    else
-    {
-        CcspTraceInfo(("NonRoot feature is enabled, dropping root privileges for RdkWanManager Process\n"));
-        init_capability();
-        drop_root_caps(&appcaps);
-        update_process_caps(&appcaps);
-        read_capability(&appcaps);
-    }
+    CcspTraceInfo(("NonRoot feature is enabled, dropping root privileges for RdkWanManager Process\n"));
+    init_capability();
+    drop_root_caps(&appcaps);
+    update_process_caps(&appcaps);
+    read_capability(&appcaps);
+   
 
     for (idx = 1; idx < argc; idx++)
     {


### PR DESCRIPTION
Reason for change: Wanmanager processes are running in non-root with rfc control, removing rfc controlled code part Test Procedure: Processes should not be able to switch back to root using RFC DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.NonRootSupport.Blocklist 
Risks: Medium
Priority: P1