### PR TITLE
XER10-1052 : MapTransportMode param value is empty after reboot.

### DIFF
--- a/source/TR-181/middle_layer_src/wanmgr_dml_dhcpv6.c
+++ b/source/TR-181/middle_layer_src/wanmgr_dml_dhcpv6.c
@@ -3482,11 +3482,14 @@ dhcp6c_mapt_mape_GetParamStringValue
         sysevent_get(sysevent_fd, sysevent_token, SYSEVENT_MAP_TRANSPORT_MODE, temp, sizeof(temp));
         if ( AnscSizeOfString(temp) < *pUlSize)
         {
-            AnscCopyString(pValue, temp);
             if ( !(*temp) )
             {
-                 AnscCopyString(pValue, "NONE");
+               AnscCopyString(pValue, "NONE");
             }
+	    else
+	    {
+	       AnscCopyString(pValue, temp);
+	    }
             return 0;
         }
         else

--- a/source/TR-181/middle_layer_src/wanmgr_dml_dhcpv6.c
+++ b/source/TR-181/middle_layer_src/wanmgr_dml_dhcpv6.c
@@ -3483,12 +3483,10 @@ dhcp6c_mapt_mape_GetParamStringValue
         if ( AnscSizeOfString(temp) < *pUlSize)
         {
             AnscCopyString(pValue, temp);
-#if defined (FEATURE_SUPPORT_MAPT_NAT46) || defined(FEATURE_MAPT)
             if ( !(*temp) )
             {
                  AnscCopyString(pValue, "NONE");
             }
-#endif
             return 0;
         }
         else

--- a/source/TR-181/middle_layer_src/wanmgr_dml_dhcpv6.c
+++ b/source/TR-181/middle_layer_src/wanmgr_dml_dhcpv6.c
@@ -3483,7 +3483,7 @@ dhcp6c_mapt_mape_GetParamStringValue
         if ( AnscSizeOfString(temp) < *pUlSize)
         {
             AnscCopyString(pValue, temp);
-#if defined (FEATURE_SUPPORT_MAPT_NAT46)
+#if defined (FEATURE_SUPPORT_MAPT_NAT46) || defined(FEATURE_MAPT)
             if ( !(*temp) )
             {
                  AnscCopyString(pValue, "NONE");


### PR DESCRIPTION
Reason for change:
Default("NONE" display before selecting MAP-T mode) DML handling for MapTransportMode parameter is missing for FEATURE_MAPT use case so this needs to be done.

Test Procedure:
1. WAN should work without any issue

Risks: Medium