### PR TITLE
SHARMAN-3449 : Global ipv6 pd address updated on erouter0 instead of brlan0 

### DIFF
--- a/config/RdkWanManager_v2.xml
+++ b/config/RdkWanManager_v2.xml
@@ -1,4 +1,39 @@
 <?xml version="1.0" encoding="utf-8" ?>
+<?define FEATURE_MAPT=True?>
+<?define RBUS_BUILD_FLAG_ENABLE=True?>
+<?define RBUS_BUILD_FLAG_ENABLE=True?>
+<?define RBUS_BUILD_FLAG_ENABLE=True?>
+<?define RBUS_BUILD_FLAG_ENABLE=True?>
+<?define FEATURE_MAPT=True?>
+<?define RBUS_BUILD_FLAG_ENABLE=True?>
+<?define RBUS_BUILD_FLAG_ENABLE=True?>
+<?define RBUS_BUILD_FLAG_ENABLE=True?>
+<?define RBUS_BUILD_FLAG_ENABLE=True?>
+<?define FEATURE_MAPT=True?>
+<?define RBUS_BUILD_FLAG_ENABLE=True?>
+<?define RBUS_BUILD_FLAG_ENABLE=True?>
+<?define RBUS_BUILD_FLAG_ENABLE=True?>
+<?define RBUS_BUILD_FLAG_ENABLE=True?>
+<?define FEATURE_MAPT=True?>
+<?define RBUS_BUILD_FLAG_ENABLE=True?>
+<?define RBUS_BUILD_FLAG_ENABLE=True?>
+<?define RBUS_BUILD_FLAG_ENABLE=True?>
+<?define RBUS_BUILD_FLAG_ENABLE=True?>
+<?define FEATURE_MAPT=True?>
+<?define RBUS_BUILD_FLAG_ENABLE=True?>
+<?define RBUS_BUILD_FLAG_ENABLE=True?>
+<?define RBUS_BUILD_FLAG_ENABLE=True?>
+<?define RBUS_BUILD_FLAG_ENABLE=True?>
+<?define FEATURE_MAPT=True?>
+<?define RBUS_BUILD_FLAG_ENABLE=True?>
+<?define RBUS_BUILD_FLAG_ENABLE=True?>
+<?define RBUS_BUILD_FLAG_ENABLE=True?>
+<?define RBUS_BUILD_FLAG_ENABLE=True?>
+<?define FEATURE_MAPT=True?>
+<?define RBUS_BUILD_FLAG_ENABLE=True?>
+<?define RBUS_BUILD_FLAG_ENABLE=True?>
+<?define RBUS_BUILD_FLAG_ENABLE=True?>
+<?define RBUS_BUILD_FLAG_ENABLE=True?>
 <!--
  If not stated otherwise in this file or this component's LICENSE file the
  following copyright and licenses apply:

--- a/config/RdkWanManager_v2.xml
+++ b/config/RdkWanManager_v2.xml
@@ -1,39 +1,4 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<?define FEATURE_MAPT=True?>
-<?define RBUS_BUILD_FLAG_ENABLE=True?>
-<?define RBUS_BUILD_FLAG_ENABLE=True?>
-<?define RBUS_BUILD_FLAG_ENABLE=True?>
-<?define RBUS_BUILD_FLAG_ENABLE=True?>
-<?define FEATURE_MAPT=True?>
-<?define RBUS_BUILD_FLAG_ENABLE=True?>
-<?define RBUS_BUILD_FLAG_ENABLE=True?>
-<?define RBUS_BUILD_FLAG_ENABLE=True?>
-<?define RBUS_BUILD_FLAG_ENABLE=True?>
-<?define FEATURE_MAPT=True?>
-<?define RBUS_BUILD_FLAG_ENABLE=True?>
-<?define RBUS_BUILD_FLAG_ENABLE=True?>
-<?define RBUS_BUILD_FLAG_ENABLE=True?>
-<?define RBUS_BUILD_FLAG_ENABLE=True?>
-<?define FEATURE_MAPT=True?>
-<?define RBUS_BUILD_FLAG_ENABLE=True?>
-<?define RBUS_BUILD_FLAG_ENABLE=True?>
-<?define RBUS_BUILD_FLAG_ENABLE=True?>
-<?define RBUS_BUILD_FLAG_ENABLE=True?>
-<?define FEATURE_MAPT=True?>
-<?define RBUS_BUILD_FLAG_ENABLE=True?>
-<?define RBUS_BUILD_FLAG_ENABLE=True?>
-<?define RBUS_BUILD_FLAG_ENABLE=True?>
-<?define RBUS_BUILD_FLAG_ENABLE=True?>
-<?define FEATURE_MAPT=True?>
-<?define RBUS_BUILD_FLAG_ENABLE=True?>
-<?define RBUS_BUILD_FLAG_ENABLE=True?>
-<?define RBUS_BUILD_FLAG_ENABLE=True?>
-<?define RBUS_BUILD_FLAG_ENABLE=True?>
-<?define FEATURE_MAPT=True?>
-<?define RBUS_BUILD_FLAG_ENABLE=True?>
-<?define RBUS_BUILD_FLAG_ENABLE=True?>
-<?define RBUS_BUILD_FLAG_ENABLE=True?>
-<?define RBUS_BUILD_FLAG_ENABLE=True?>
 <!--
  If not stated otherwise in this file or this component's LICENSE file the
  following copyright and licenses apply:

--- a/source/TR-181/middle_layer_src/wanmgr_rdkbus_utils.c
+++ b/source/TR-181/middle_layer_src/wanmgr_rdkbus_utils.c
@@ -1152,3 +1152,43 @@ void Wanmgr_TriggerReboot()
         CcspTraceError(("%s %d: WanManager Failed to trigger reboot \n", __FUNCTION__, __LINE__));
     }
 }
+
+#define PAM_LANMODE_DML "Device.X_CISCO_COM_DeviceControl.LanManagementEntry.1.LanMode"
+
+/**
+ * @brief Checks if the system is operating in Bridge Mode based on the 
+ *        configuration from the PandM module.
+ *
+ * This function determines whether the current LAN bridge configuration
+ * is set to Bridge Mode by querying the PandM  module.
+ *
+ * @return BOOL
+ *         - TRUE if the system is in Bridge Mode.
+ *         - FALSE otherwise.
+ */
+
+BOOL WanMgr_isBridgeModeFromPandM()
+{
+    char dmlValue[64] = {0};
+
+    //Query
+    if (ANSC_STATUS_FAILURE == WanMgr_RdkBus_GetParamValues(PAM_COMPONENT_NAME, PAM_DBUS_PATH, PAM_LANMODE_DML, dmlValue))
+    {
+        CcspTraceError(("[%s][%d] Failed to get param value\n", __FUNCTION__, __LINE__));
+        return FALSE;
+    }
+
+    //Possible DML values  bridge-dhcp(1),bridge-static(2),router(3)
+    if(strncmp(dmlValue, "bridge-", strlen("bridge-")) == 0)
+    {
+        CcspTraceInfo(("%s %d - Bridge Mode is enabled\n", __FUNCTION__, __LINE__));
+        return TRUE;
+    }
+    else
+    {
+        CcspTraceInfo(("%s %d - Bridge Mode is disabled\n", __FUNCTION__, __LINE__));
+        return FALSE;
+    }
+
+    return FALSE;
+}

--- a/source/TR-181/middle_layer_src/wanmgr_rdkbus_utils.c
+++ b/source/TR-181/middle_layer_src/wanmgr_rdkbus_utils.c
@@ -1153,7 +1153,7 @@ void Wanmgr_TriggerReboot()
     }
 }
 
-#define PAM_LANMODE_DML "Device.X_CISCO_COM_DeviceControl.LanManagementEntry.1.LanMode"
+#define TR181_LANMODE_PARAM "Device.X_CISCO_COM_DeviceControl.LanManagementEntry.1.LanMode"
 
 /**
  * @brief Checks if the system is operating in Bridge Mode based on the 
@@ -1167,26 +1167,26 @@ void Wanmgr_TriggerReboot()
  *         - FALSE otherwise.
  */
 
-BOOL WanMgr_isBridgeModeFromPandM()
+BOOL WanMgr_isBridgeModeEnabled()
 {
     char dmlValue[64] = {0};
 
     //Query
-    if (ANSC_STATUS_FAILURE == WanMgr_RdkBus_GetParamValues(PAM_COMPONENT_NAME, PAM_DBUS_PATH, PAM_LANMODE_DML, dmlValue))
+    if (ANSC_STATUS_FAILURE == WanMgr_RdkBus_GetParamValues(PAM_COMPONENT_NAME, PAM_DBUS_PATH, TR181_LANMODE_PARAM, dmlValue))
     {
         CcspTraceError(("[%s][%d] Failed to get param value\n", __FUNCTION__, __LINE__));
         return FALSE;
     }
 
-    //Possible DML values  bridge-dhcp(1),bridge-static(2),router(3)
-    if(strncmp(dmlValue, "bridge-", strlen("bridge-")) == 0)
+    //Possible DML values  bridge-dhcp,bridge-static,router
+    if(strcmp(dmlValue, "bridge-dhcp") == 0 || strcmp(dmlValue, "bridge-static") == 0 || strcmp(dmlValue, "full-bridge-static") == 0)
     {
-        CcspTraceInfo(("%s %d - Bridge Mode is enabled\n", __FUNCTION__, __LINE__));
+        CcspTraceInfo(("%s %d - CPE is in Bridge Mode\n", __FUNCTION__, __LINE__));
         return TRUE;
     }
     else
     {
-        CcspTraceInfo(("%s %d - Bridge Mode is disabled\n", __FUNCTION__, __LINE__));
+        CcspTraceInfo(("%s %d - CPE is in Router Mode\n", __FUNCTION__, __LINE__));
         return FALSE;
     }
 

--- a/source/TR-181/middle_layer_src/wanmgr_rdkbus_utils.h
+++ b/source/TR-181/middle_layer_src/wanmgr_rdkbus_utils.h
@@ -236,5 +236,5 @@ void Wanmgr_TriggerReboot();
  *         - FALSE otherwise.
  */
 
- BOOL WanMgr_isBridgeModeFromPandM();
+ BOOL WanMgr_isBridgeModeEnabled();
 #endif /* _WANMGR_RDKBUS_UTILS_H_ */

--- a/source/TR-181/middle_layer_src/wanmgr_rdkbus_utils.h
+++ b/source/TR-181/middle_layer_src/wanmgr_rdkbus_utils.h
@@ -224,4 +224,17 @@ ANSC_STATUS WanMgr_SetConnectivityCheckTypeToPSM(DML_VIRTUAL_IFACE* pVirtIf, CON
  */
 void Wanmgr_TriggerReboot();
 
+/**
+ * @brief Checks if the system is operating in Bridge Mode based on the 
+ *        configuration from the PandM module.
+ *
+ * This function determines whether the current LAN bridge configuration
+ * is set to Bridge Mode by querying the PandM  module.
+ *
+ * @return BOOL
+ *         - TRUE if the system is in Bridge Mode.
+ *         - FALSE otherwise.
+ */
+
+ BOOL WanMgr_isBridgeModeFromPandM();
 #endif /* _WANMGR_RDKBUS_UTILS_H_ */

--- a/source/WanManager/wanmgr_interface_sm.c
+++ b/source/WanManager/wanmgr_interface_sm.c
@@ -974,19 +974,25 @@ static int checkIpv6LanAddressIsReadyToUse(DML_VIRTUAL_IFACE* p_VirtIf)
     int dad_flag       = 0;
     int route_flag     = 0;
     int i;
-    char Output[BUFLEN_16] = {0};
     char IfaceName[BUFLEN_16] = {0};
     int BridgeMode = 0;
 
-
+    { //TODO : temporary debug code to identify the bridgemode sysevent failure issue.
+        char Output[BUFLEN_16] = {0};
+        if (sysevent_get(sysevent_fd, sysevent_token, "bridge_mode", Output, sizeof(Output)) !=0)
+        {
+            CcspTraceError(("%s-%d: bridge_mode sysevent get failed. \n", __FUNCTION__, __LINE__));
+        }
+        BridgeMode = atoi(Output);
+        CcspTraceInfo(("%s-%d: Bridge mode value set to BridgeMode=%d \n", __FUNCTION__, __LINE__,  BridgeMode));
+    }
      /*TODO:
      *Below Code should be removed once V6 Prefix/IP is assigned on erouter0 Instead of brlan0 for sky Devices.
      */
     strncpy(IfaceName, ETH_BRIDGE_NAME, sizeof(IfaceName)-1);
-    sysevent_get(sysevent_fd, sysevent_token, "bridge_mode", Output, sizeof(Output));
-    BridgeMode = atoi(Output);
-    if (BridgeMode != 0)
+    if (WanMgr_isBridgeModeFromPandM() == TRUE)
     {
+        CcspTraceInfo(("%s-%d: Device is in bridge mode. Assigning IPv6 address on WAN interface.\n", __FUNCTION__, __LINE__));
         memset(IfaceName, 0, sizeof(IfaceName));
         strncpy(IfaceName, p_VirtIf->Name, sizeof(IfaceName)-1);
     }

--- a/source/WanManager/wanmgr_interface_sm.c
+++ b/source/WanManager/wanmgr_interface_sm.c
@@ -984,13 +984,13 @@ static int checkIpv6LanAddressIsReadyToUse(DML_VIRTUAL_IFACE* p_VirtIf)
             CcspTraceError(("%s-%d: bridge_mode sysevent get failed. \n", __FUNCTION__, __LINE__));
         }
         BridgeMode = atoi(Output);
-        CcspTraceInfo(("%s-%d: Bridge mode value set to BridgeMode=%d \n", __FUNCTION__, __LINE__,  BridgeMode));
+        CcspTraceInfo(("%s-%d: <<DEBUG>> bridge_mode sysevent value set to =%d \n", __FUNCTION__, __LINE__,  BridgeMode));
     }
      /*TODO:
      *Below Code should be removed once V6 Prefix/IP is assigned on erouter0 Instead of brlan0 for sky Devices.
      */
     strncpy(IfaceName, ETH_BRIDGE_NAME, sizeof(IfaceName)-1);
-    if (WanMgr_isBridgeModeFromPandM() == TRUE)
+    if (WanMgr_isBridgeModeEnabled() == TRUE)
     {
         CcspTraceInfo(("%s-%d: Device is in bridge mode. Assigning IPv6 address on WAN interface.\n", __FUNCTION__, __LINE__));
         memset(IfaceName, 0, sizeof(IfaceName));

--- a/source/WanManager/wanmgr_net_utils.c
+++ b/source/WanManager/wanmgr_net_utils.c
@@ -330,7 +330,6 @@ int WanManager_Ipv6AddrUtil(char *ifname, Ipv6OperType opr, int preflft, int val
     char cmdLine[128] = {0};
     char prefix[BUFLEN_48] = {0};
     char prefixAddr[BUFLEN_48] = {0};
-    char Output[BUFLEN_16] = {0};
     char IfaceName[BUFLEN_16] = {0};
     int BridgeMode = 0;
 
@@ -340,19 +339,27 @@ int WanManager_Ipv6AddrUtil(char *ifname, Ipv6OperType opr, int preflft, int val
     memset(prefixAddr, 0, sizeof(prefixAddr));
     sysevent_get(sysevent_fd, sysevent_token, SYSEVENT_GLOBAL_IPV6_PREFIX_SET, prefixAddr, sizeof(prefixAddr));
 
+    { //TODO : temporary debug code to identify the bridgemode sysevent failure issue.
+        char Output[BUFLEN_16] = {0};
+        if (sysevent_get(sysevent_fd, sysevent_token, "bridge_mode", Output, sizeof(Output)) !=0)
+        {
+            CcspTraceError(("%s-%d: bridge_mode sysevent get failed. \n", __FUNCTION__, __LINE__));
+        }
+        BridgeMode = atoi(Output);
+        CcspTraceInfo(("%s-%d: Bridge mode value set to BridgeMode=%d \n", __FUNCTION__, __LINE__,  BridgeMode));
+    }
+
     /*TODO:
      *Below Code should be removed once V6 Prefix/IP is assigned on erouter0 Instead of brlan0 for sky Devices. 
      */
     strcpy(IfaceName, LAN_BRIDGE_NAME);
-    sysevent_get(sysevent_fd, sysevent_token, "bridge_mode", Output, sizeof(Output));
-    BridgeMode = atoi(Output);
-    if (BridgeMode != 0)
+    if (WanMgr_isBridgeModeFromPandM() == TRUE)
     {
         memset(IfaceName, 0, sizeof(IfaceName));
         strncpy(IfaceName, ifname, strlen(ifname));
     }
 
-    CcspTraceInfo(("%s-%d: IfaceName=%s, BridgeMode=%d \n", __FUNCTION__, __LINE__, IfaceName, BridgeMode));
+    CcspTraceInfo(("%s-%d: IfaceName=%s \n", __FUNCTION__, __LINE__, IfaceName));
 
     switch (opr)
     {

--- a/source/WanManager/wanmgr_net_utils.c
+++ b/source/WanManager/wanmgr_net_utils.c
@@ -346,14 +346,14 @@ int WanManager_Ipv6AddrUtil(char *ifname, Ipv6OperType opr, int preflft, int val
             CcspTraceError(("%s-%d: bridge_mode sysevent get failed. \n", __FUNCTION__, __LINE__));
         }
         BridgeMode = atoi(Output);
-        CcspTraceInfo(("%s-%d: Bridge mode value set to BridgeMode=%d \n", __FUNCTION__, __LINE__,  BridgeMode));
+        CcspTraceInfo(("%s-%d: <<DEBUG>> bridge_mode sysevent value set to =%d \n", __FUNCTION__, __LINE__,  BridgeMode));
     }
 
     /*TODO:
      *Below Code should be removed once V6 Prefix/IP is assigned on erouter0 Instead of brlan0 for sky Devices. 
      */
     strcpy(IfaceName, LAN_BRIDGE_NAME);
-    if (WanMgr_isBridgeModeFromPandM() == TRUE)
+    if (WanMgr_isBridgeModeEnabled() == TRUE)
     {
         memset(IfaceName, 0, sizeof(IfaceName));
         strncpy(IfaceName, ifname, strlen(ifname));

--- a/source/WanManager/wanmgr_sysevents.c
+++ b/source/WanManager/wanmgr_sysevents.c
@@ -1152,7 +1152,7 @@ static int CheckV6DefaultRule (char *wanInterface)
 
     if ((fp = v_secure_popen("r", "ip -6 ro")) == NULL)
     {
-        CcspTraceError(("Failed to open file descripter %d \n"));
+        CcspTraceError(("%s %d - Failed to open file descripter %d(%s) \n", __FUNCTION__, __LINE__, errno, strerror(errno)));
         return FALSE;
     }
 
@@ -1172,7 +1172,7 @@ static int CheckV6DefaultRule (char *wanInterface)
     {
         CcspTraceError(("Failed in closing the pipe ret %d \n",pclose_ret));
     }
-
+    CcspTraceInfo(("%s %d - Default route %sfound for interface %s\n", __FUNCTION__, __LINE__, (ret == TRUE) ? "" : "not ", wanInterface));
     return ret;
 }
 

--- a/source/WanManager/wanmgr_sysevents.c
+++ b/source/WanManager/wanmgr_sysevents.c
@@ -67,6 +67,7 @@ extern int WanMgr_TriggerPrimaryDnsConnectivityRestart(void);
 #endif
 #endif
 
+static int isDefaultGatewayAdded = 0; //global varibale for default route status.
 static int lan_wan_started = 0;
 static int ipv4_connection_up = 0;
 static int ipv6_connection_up = 0;
@@ -582,6 +583,7 @@ static void *WanManagerSyseventHandler(void *args)
 
     async_id_t wanamangr_status_asyncid;
     async_id_t lan_ula_address_event_asyncid;
+    async_id_t default_route_change_event_asyncid;
     async_id_t lan_ula_enable_asyncid;
     async_id_t lan_ipv6_enable_asyncid;
     async_id_t wan_status_asyncid;
@@ -616,6 +618,8 @@ static void *WanManagerSyseventHandler(void *args)
 #endif
 #endif
 
+    sysevent_set_options(sysevent_msg_fd, sysevent_msg_token, SYSEVENT_IPV6_TOGGLE, TUPLE_FLAG_EVENT);
+    sysevent_setnotification(sysevent_msg_fd, sysevent_msg_token, SYSEVENT_IPV6_TOGGLE, &default_route_change_event_asyncid);
 #if defined (_HUB4_PRODUCT_REQ_) || defined(_RDKB_GLOBAL_PRODUCT_REQ_)
     sysevent_set_options(sysevent_msg_fd, sysevent_msg_token, SYSEVENT_ULA_ADDRESS, TUPLE_FLAG_EVENT);
     sysevent_setnotification(sysevent_msg_fd, sysevent_msg_token, SYSEVENT_ULA_ADDRESS, &lan_ula_address_event_asyncid);
@@ -743,6 +747,19 @@ static void *WanManagerSyseventHandler(void *args)
                     CcspTraceError(("%s %d failed set command: %s\n", __FUNCTION__, __LINE__, cmd_str));
                 }
 		#endif
+            }
+            else if ( strcmp(name, SYSEVENT_IPV6_TOGGLE) == 0 )
+            {
+                if(strcmp(val, "FALSE") == 0)
+                {
+                    isDefaultGatewayAdded = 1;
+                    CcspTraceWarning(("%s %d Netmonitor Update : IPv6 default route Added \n", __FUNCTION__, __LINE__ ));
+                }
+                else
+                {
+                    isDefaultGatewayAdded = 0;
+                    CcspTraceWarning(("%s %d Netmonitor Update : IPv6 default route Deleted \n", __FUNCTION__, __LINE__ ));
+                }
             }
             else if ( strcmp(name, SYSEVENT_ULA_ENABLE) == 0 )
             {
@@ -1135,6 +1152,7 @@ static int CheckV6DefaultRule (char *wanInterface)
 
     if ((fp = v_secure_popen("r", "ip -6 ro")) == NULL)
     {
+        CcspTraceError(("Failed to open file descripter %d \n"));
         return FALSE;
     }
 
@@ -1179,8 +1197,8 @@ int Force_IPv6_toggle (char* wanInterface)
         CcspTraceWarning(("%s-%d : Failure writing to /proc file\n", __FUNCTION__, __LINE__));
     }
 
-    sysevent_set(sysevent_fd, sysevent_token, SYSEVENT_IPV6_TOGGLE, "FALSE", 0); //Reset toggle flag to false.
-
+    isDefaultGatewayAdded = 1; //Reset isDefaultGatewayAdded flag;
+    
     return ret;
 }
 
@@ -1191,17 +1209,13 @@ int Force_IPv6_toggle (char* wanInterface)
  */
 void WanMgr_CheckDefaultRA (DML_VIRTUAL_IFACE * pVirtIf)
 {
-    char v6Toggle[BUFLEN_128] = {0};
-    //TODO : Move router monitor to a WanManager thread ? to avoid continous sysevent get
-    sysevent_get(sysevent_fd, sysevent_token, SYSEVENT_IPV6_TOGGLE, v6Toggle, sizeof(v6Toggle));
-
-    if((strlen(v6Toggle) == 0) || (!strcmp(v6Toggle,"TRUE")))
+    //TODO : Move router monitor to a WanManager thread ? 
+    if(!isDefaultGatewayAdded )
     {
-        CcspTraceInfo(("%s %d SYSEVENT_IPV6_TOGGLE[TRUE] \n", __FUNCTION__, __LINE__));
         //TODO: add check for remote device ( static ip )
         if (CheckV6DefaultRule(pVirtIf->Name) == TRUE ||  WanManager_send_and_receive_rs(pVirtIf) == 0)
         {
-            sysevent_set(sysevent_fd, sysevent_token, SYSEVENT_IPV6_TOGGLE, "FALSE", 0);
+            isDefaultGatewayAdded = 1; //Reset isDefaultGatewayAdded flag;
         }
     }
 }

--- a/source/WanManager/wanmgr_utils.c
+++ b/source/WanManager/wanmgr_utils.c
@@ -1075,12 +1075,12 @@ int sysctl_iface_set(const char *path, const char *ifname, const char *content)
         filename = path;
 
     if ((fd = open(filename, O_WRONLY)) < 0) {
-        CcspTraceError(("Failed to open file %s, errno: %d (%s)\n", filename, errno, strerror(errno)));
+        CcspTraceError(("%s %d: Failed to open file %s, errno: %d (%s)\n", __FUNCTION__, __LINE__, filename, errno, strerror(errno)));
         return -1;
     }
     len = strlen(content);
     if (write(fd, content, len) != (ssize_t) len) {
-        CcspTraceError(("Failed to open file %s, errno: %d (%s)\n", filename, errno, strerror(errno)));
+        CcspTraceError(("%s %d: Failed to open file %s, errno: %d (%s)\n", __FUNCTION__, __LINE__, filename, errno, strerror(errno)));
         perror("Failed to write to file");
         close(fd);
         return -1;

--- a/source/WanManager/wanmgr_utils.c
+++ b/source/WanManager/wanmgr_utils.c
@@ -1075,12 +1075,12 @@ int sysctl_iface_set(const char *path, const char *ifname, const char *content)
         filename = path;
 
     if ((fd = open(filename, O_WRONLY)) < 0) {
-        perror("Failed to open file");
+        CcspTraceError(("Failed to open file %s, errno: %d (%s)\n", filename, errno, strerror(errno)));
         return -1;
     }
-
     len = strlen(content);
     if (write(fd, content, len) != (ssize_t) len) {
+        CcspTraceError(("Failed to open file %s, errno: %d (%s)\n", filename, errno, strerror(errno)));
         perror("Failed to write to file");
         close(fd);
         return -1;


### PR DESCRIPTION
SHARMAN-3449 : Global ipv6 PD updated on erouter0 instead of brlan0
Reason for change:
Replcaing bridge_mode sysevent query with TR181 DML

Test Procedure:
Updated in Jira.

Risks: none
Priority: P1