### PR TITLE
RDKB-59976 : IPv6 not Allocated to Wi-Fi Clients

### DIFF
--- a/source/WanManager/wanmgr_dhcpv6_apis.c
+++ b/source/WanManager/wanmgr_dhcpv6_apis.c
@@ -2112,7 +2112,10 @@ int setUpLanPrefixIPv6(DML_VIRTUAL_IFACE* pVirtIf)
 
     CcspTraceWarning(("%s: setting lan-restart\n", __FUNCTION__));
     sysevent_set(sysevent_fd, sysevent_token, "lan-restart", "1", 0);
-
+#if defined(CISCO_CONFIG_DHCPV6_PREFIX_DELEGATION) && ! defined(DHCPV6_PREFIX_FIX) 
+    CcspTraceWarning(("%s: setting dhcpv6_server-restart\n", __FUNCTION__));
+    sysevent_set(sysevent_fd, sysevent_token, "dhcpv6_server-restart", "", 0);
+#else
     // Below code copied from CosaDmlDHCPv6sTriggerRestart(FALSE) PAm function.
     int fd = 0;
     char str[32] = "restart";
@@ -2124,6 +2127,7 @@ int setUpLanPrefixIPv6(DML_VIRTUAL_IFACE* pVirtIf)
     }
     write( fd, str, sizeof(str) );
     close(fd);
+#endif
 #endif
 #endif
     return RETURN_OK;


### PR DESCRIPTION
Reason for change:  adding dhcpv6_server-restart sysevent for DHCpv6 server restart

Test Procedure:
Updated in Jira.

Risks: none
Priority: P1