### PR TITLE
RDKB-57776: Develop ifacemanager_vlan for VlanManager.

### DIFF
--- a/source/WanManager/wanmgr_policy_auto_impl.c
+++ b/source/WanManager/wanmgr_policy_auto_impl.c
@@ -1448,7 +1448,7 @@ static WcAwPolicyState_t State_WanInterfaceActive (WanMgr_Policy_Controller_t * 
     DML_WAN_IFACE * pActiveInterface = &(pWanController->pWanActiveIfaceData->data);
     if (pActiveInterface->BaseInterfaceStatus != WAN_IFACE_PHY_STATUS_UP ||
             pActiveInterface->Selection.Enable == FALSE || 
-            (WanMgr_Get_ISM_RunningStatus(pWanController->activeInterfaceIdx) != TRUE))
+            (WanMgr_Get_ISM_RunningStatus(pWanController->activeInterfaceIdx) != TRUE)) //TBC: This check is workaround to avoid the race condition of BaseInterfaceStatus notification reception
     {
         CcspTraceInfo(("%s %d: interface:%d is BaseInterface down\n", __FUNCTION__, __LINE__, pWanController->activeInterfaceIdx));
         if (WanMgr_SetGroupSelectedIface (pWanController->GroupInst, (pWanController->activeInterfaceIdx+1)) != ANSC_STATUS_SUCCESS)


### PR DESCRIPTION
Reason for change:
Interface state machine is not starting again when Physical Status of Interface has been received prior than WAN Interface State Machine Exit. So policy doesn't know about this status and unable to handle this. so this race condition needs to be addressed.

Test Procedure:
1. WAN functionality should work without any issue

Risks: Low