### PR TITLE
RDKB-60146 : Skip deactivated groups during high priority marking

### DIFF
--- a/source/WanManager/wanmgr_wan_failover.c
+++ b/source/WanManager/wanmgr_wan_failover.c
@@ -473,7 +473,8 @@ ANSC_STATUS MarkHighPriorityGroup (WanMgr_FailOver_Controller_t* pFailOverContro
                 if (pWanDmlIfaceData != NULL)
                 {
                     DML_WAN_IFACE* pWanIfaceData = &(pWanDmlIfaceData->data);
-                    if((pWanIfaceData->VirtIfList->Status == WAN_IFACE_STATUS_STANDBY ||
+                    if(pWanIfaceGroup->State != STATE_GROUP_DEACTIVATED && // Group should not be in DEACTIVATED state
+                        (pWanIfaceData->VirtIfList->Status == WAN_IFACE_STATUS_STANDBY ||
                         pWanIfaceData->VirtIfList->Status == WAN_IFACE_STATUS_UP) &&
                         (!(pWanIfaceData->IfaceType == REMOTE_IFACE &&  // Check RemoteStatus also for REMOTE_IFACE
                         pWanIfaceData->VirtIfList->RemoteStatus != WAN_IFACE_STATUS_UP)) && 


### PR DESCRIPTION
Skip deactivated groups during high priority marking

Updated `MarkHighPriorityGroup` logic to exclude WAN interface groups in `STATE_GROUP_DEACTIVATED` state from being marked as high priority. This ensures only active groups with interfaces in STANDBY or UP status are considered, improving failover accuracy.