### PR TITLE
RDKCOM-5438: RDKBDEV-3293 Fix Condition check for adding default IPv6 route in WANManager

### DIFF
--- a/source/WanManager/wanmgr_interface_sm.c
+++ b/source/WanManager/wanmgr_interface_sm.c
@@ -1052,7 +1052,9 @@ static int checkIpv6LanAddressIsReadyToUse(DML_VIRTUAL_IFACE* p_VirtIf)
     }
 
     buffer[0] = '\0';
-    if ((fp_route = popen("ip -6 ro | grep default", "r"))) {
+    char cmd[128];
+    snprintf(cmd, sizeof(cmd), "ip -6 ro show default dev %s", p_VirtIf->Name);
+    if ((fp_route = popen(cmd, "r"))) {
         if(fp_route != NULL) {
             fgets(buffer, BUFLEN_256, fp_route);
             if(strlen(buffer) > 0 ) {


### PR DESCRIPTION
Reason for change: After enabling Wan Manager Unification flag in MXL build, we observed that default IPv6 route for erouter0 was not getting added in CM during bootup. So fixed condition check to specifically check erouter0 interface while adding route. 

Risks: Low

Signed-off-by: Aiswarya Prasad <aprasad@maxlinear.com>