### PR TITLE
RDKB-63844: Fix DHCP client events processed out of order

### DIFF
--- a/source/TR-181/middle_layer_src/wanmgr_rbus_dhcp_client_events.c
+++ b/source/TR-181/middle_layer_src/wanmgr_rbus_dhcp_client_events.c
@@ -28,6 +28,98 @@
 
 extern rbusHandle_t rbusHandle;
 
+/*
+ * DHCP event queue – FIFO linked list protected by mutex + condvar.
+ * A single persistent worker thread drains the queue so events are
+ * always processed in the order they arrive.
+ */
+static DhcpEventThreadArgs *g_dhcpEventQueueHead = NULL;
+static DhcpEventThreadArgs *g_dhcpEventQueueTail = NULL;
+static pthread_mutex_t      g_dhcpEventQueueMutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t       g_dhcpEventQueueCond  = PTHREAD_COND_INITIALIZER;
+static int                  g_dhcpEventWorkerRunning = 0;
+
+/* Worker thread: drains the queue in strict FIFO order. */
+static void* WanMgr_DhcpEventQueueWorker(void *arg)
+{
+    (void)arg;
+    pthread_detach(pthread_self());
+
+    while (1)
+    {
+        DhcpEventThreadArgs *eventData = NULL;
+
+        pthread_mutex_lock(&g_dhcpEventQueueMutex);
+        /* Wait until there is at least one event in the queue */
+        while (g_dhcpEventQueueHead == NULL)
+        {
+            pthread_cond_wait(&g_dhcpEventQueueCond, &g_dhcpEventQueueMutex);
+        }
+
+        /* Dequeue the head element */
+        eventData = g_dhcpEventQueueHead;
+        g_dhcpEventQueueHead = eventData->next;
+        if (g_dhcpEventQueueHead == NULL)
+        {
+            g_dhcpEventQueueTail = NULL;
+        }
+        eventData->next = NULL;
+        pthread_mutex_unlock(&g_dhcpEventQueueMutex);
+
+        /* Process the event — this runs outside the queue lock so that
+         * new events can still be enqueued while we process. */
+        CcspTraceInfo(("%s-%d : Dequeued DHCP event (type %d) for %s\n",
+                       __FUNCTION__, __LINE__, eventData->type, eventData->ifName));
+        WanMgr_ProcessDhcpClientEvent(eventData);
+        free(eventData);
+    }
+
+    return NULL;
+}
+
+/* Enqueue a DHCP event and ensure the worker thread is running. */
+void WanMgr_DhcpEventQueue_Enqueue(DhcpEventThreadArgs *eventData)
+{
+    if (eventData == NULL)
+    {
+        return;
+    }
+
+    eventData->next = NULL;
+
+    pthread_mutex_lock(&g_dhcpEventQueueMutex);
+
+    /* Append to tail of queue */
+    if (g_dhcpEventQueueTail != NULL)
+    {
+        g_dhcpEventQueueTail->next = eventData;
+    }
+    else
+    {
+        g_dhcpEventQueueHead = eventData;
+    }
+    g_dhcpEventQueueTail = eventData;
+
+    /* Start the worker thread on first use */
+    if (!g_dhcpEventWorkerRunning)
+    {
+        pthread_t workerThread;
+        if (pthread_create(&workerThread, NULL, WanMgr_DhcpEventQueueWorker, NULL) == 0)
+        {
+            g_dhcpEventWorkerRunning = 1;
+            CcspTraceInfo(("%s-%d : DHCP event queue worker thread started\n", __FUNCTION__, __LINE__));
+        }
+        else
+        {
+            CcspTraceError(("%s-%d : Failed to create DHCP event queue worker thread\n", __FUNCTION__, __LINE__));
+        }
+    }
+
+    /* Signal the worker that a new event is available */
+    pthread_cond_signal(&g_dhcpEventQueueCond);
+    pthread_mutex_unlock(&g_dhcpEventQueueMutex);
+}
+
 static void WanMgr_DhcpClientEventsHandler(rbusHandle_t handle, rbusEvent_t const* event, rbusEventSubscription_t* subscription)
 {
     (void)handle;
@@ -40,8 +132,6 @@ static void WanMgr_DhcpClientEventsHandler(rbusHandle_t handle, rbusEvent_t cons
         CcspTraceError(("%s : FAILED , value is NULL\n",__FUNCTION__));
         return;
     }
-
-    pthread_t dhcpEvent_thread;
 
     //CcspTraceInfo(("%s %d: Received %s\n", __FUNCTION__, __LINE__, eventName));
     if (strstr(eventName, DHCP_MGR_DHCPv4_TABLE) || strstr(eventName, DHCP_MGR_DHCPv6_TABLE) )
@@ -86,14 +176,8 @@ static void WanMgr_DhcpClientEventsHandler(rbusHandle_t handle, rbusEvent_t cons
             }
         }
 
-        if(pthread_create(&dhcpEvent_thread, NULL, WanMgr_DhcpClientEventsHandler_Thread, eventData) != 0)
-        {
-            CcspTraceError(("%s %d: Failed to create thread for DHCPv4 event\n", __FUNCTION__, __LINE__));
-            free(eventData);
-            return;
-        }
-        /* Adding sleep to make sure the thread locks the DhcpClientEvents_mutex */
-        usleep(10000);
+        /* Enqueue the event for ordered processing by the worker thread */
+        WanMgr_DhcpEventQueue_Enqueue(eventData);
     }
 }
 
@@ -106,7 +190,7 @@ void WanMgr_SubscribeDhcpClientEvents(const char *DhcpInterface)
     if(rc != RBUS_ERROR_SUCCESS)
     {
         CcspTraceError(("%s %d - Failed to Subscribe %s, Error=%s \n", __FUNCTION__, __LINE__, eventName, rbusError_ToString(rc)));
-        return NULL;
+        return;
     }
     
     CcspTraceInfo(("%s %d: Subscribed to %s  n", __FUNCTION__, __LINE__, eventName));
@@ -121,7 +205,7 @@ void WanMgr_UnSubscribeDhcpClientEvents(const char *DhcpInterface)
     if(rc != RBUS_ERROR_SUCCESS)
     {
         CcspTraceError(("%s %d - Failed to UnSubscribe %s, Error=%s \n", __FUNCTION__, __LINE__, eventName, rbusError_ToString(rc)));
-        return NULL;
+        return;
     }
     
     CcspTraceInfo(("%s %d: UnSubscribed to %s  n", __FUNCTION__, __LINE__, eventName));

--- a/source/WanManager/wanmgr_dhcp_client_events.h
+++ b/source/WanManager/wanmgr_dhcp_client_events.h
@@ -35,7 +35,13 @@ typedef struct _DhcpEventThreadArgs
         DHCP_MGR_IPV4_MSG v4;
         DHCP_MGR_IPV6_MSG v6;
     }lease;
+    struct _DhcpEventThreadArgs *next; /* linked-list pointer for event queue */
 }DhcpEventThreadArgs;
 
-void* WanMgr_DhcpClientEventsHandler_Thread(void *arg);
+/* Process a single DHCP client event (called by queue worker thread). */
+void WanMgr_ProcessDhcpClientEvent(DhcpEventThreadArgs *eventData);
+
+/* Enqueue a DHCP event for ordered processing; starts worker thread on first call. */
+void WanMgr_DhcpEventQueue_Enqueue(DhcpEventThreadArgs *eventData);
+
 #endif //_WANMGR_DHCP_EVENTS_H_

--- a/source/WanManager/wanmgr_dhcp_event_handler.c
+++ b/source/WanManager/wanmgr_dhcp_event_handler.c
@@ -155,6 +155,22 @@ void WanMgr_ProcessDhcpClientEvent(DhcpEventThreadArgs *eventData)
 
                 case DHCP_LEASE_UPDATE:
                     CcspTraceInfo(("%s-%d : DHCPv4 lease updated for %s\n", __FUNCTION__, __LINE__, pVirtIf->Name));
+                    /* A gateway of 0.0.0.0 indicates a private lease used solely for
+                     * validity and authentication of the WAN connection. This lease must
+                     * not be used for internet traffic. In this case, only mark the
+                     * interface as VALID and wait for the DHCPv6 lease (with MAP-T) to
+                     * establish the actual internet-capable connection. */
+                    if (strcmp(eventData->lease.v4.gateway, "0.0.0.0") == 0)
+                    {
+                        //Don't set the status to VALID if it is already UP or STANDBY
+                        if (pVirtIf->Status != WAN_IFACE_STATUS_STANDBY && pVirtIf->Status != WAN_IFACE_STATUS_UP)
+                        {
+                            CcspTraceInfo(("%s %d - gateway=[%s] Setting Iface Status to VALID\n", __FUNCTION__, __LINE__, eventData->lease.v4.gateway));
+                            pVirtIf->Status = WAN_IFACE_STATUS_VALID;
+                        }
+                        break;
+                    }
+
                     copyDhcpv4Data(&(pVirtIf->IP.Ipv4Data), &(eventData->lease.v4));
                     pVirtIf->IP.Ipv4Changed = TRUE;
                     WanManager_UpdateInterfaceStatus(pVirtIf, WANMGR_IFACE_CONNECTION_UP);
@@ -162,7 +178,6 @@ void WanMgr_ProcessDhcpClientEvent(DhcpEventThreadArgs *eventData)
                     char param_name[256] = {0};
                     snprintf(param_name, sizeof(param_name), "Device.X_RDK_WanManager.Interface.%d.VirtualInterface.%d.IP.IPv4Address", pVirtIf->baseIfIdx + 1, pVirtIf->VirIfIdx + 1);
                     WanMgr_Rbus_EventPublishHandler(param_name, pVirtIf->IP.Ipv4Data.ip, RBUS_STRING);
-                    // TODO: Check for sysevents
                     break;
 
                 default:

--- a/source/WanManager/wanmgr_dhcp_event_handler.c
+++ b/source/WanManager/wanmgr_dhcp_event_handler.c
@@ -106,13 +106,18 @@ static void copyDhcpv6Data(WANMGR_IPV6_DATA* pDhcpv6Data, const DHCP_MGR_IPV6_MS
     pDhcpv6Data->ipv6_TimeOffset = leaseInfo->ipv6_TimeOffset;
 }
 
-pthread_mutex_t DhcpClientEvents_mutex = PTHREAD_MUTEX_INITIALIZER;
-
-void* WanMgr_DhcpClientEventsHandler_Thread(void *arg)
+/*
+ * Process a single DHCP client event.  Called by the queue worker thread
+ * so events are guaranteed to be handled in FIFO order.
+ * Caller is responsible for freeing eventData after this returns.
+ */
+void WanMgr_ProcessDhcpClientEvent(DhcpEventThreadArgs *eventData)
 {
-    DhcpEventThreadArgs *eventData = (DhcpEventThreadArgs *)arg;
-    pthread_mutex_lock(&DhcpClientEvents_mutex);
-    pthread_detach(pthread_self());
+    if (eventData == NULL)
+    {
+        CcspTraceError(("%s-%d : eventData is NULL\n", __FUNCTION__, __LINE__));
+        return;
+    }
 
     DML_VIRTUAL_IFACE* pVirtIf = WanMgr_GetVIfByName_VISM_running_locked(eventData->ifName);
     if(pVirtIf != NULL)
@@ -262,8 +267,4 @@ void* WanMgr_DhcpClientEventsHandler_Thread(void *arg)
         } 
         WanMgr_VirtualIfaceData_release(pVirtIf);
     }
-    free(eventData);
-    pthread_mutex_unlock(&DhcpClientEvents_mutex);
-    pthread_exit(NULL);
-    return NULL;
 }


### PR DESCRIPTION
Replace per-event thread creation with a FIFO event queue and a single persistent worker thread. Previously each rbus DHCP event spawned a new thread that raced for DhcpClientEvents_mutex, and a usleep(10000) hack could not guarantee ordering.

Changes:
- Add 'next' pointer to DhcpEventThreadArgs for linked-list queue
- Add WanMgr_DhcpEventQueue_Enqueue(): thread-safe enqueue with
  mutex + condvar, starts worker thread on first call
- Add WanMgr_DhcpEventQueueWorker(): persistent thread that blocks
  on condvar, dequeues head, processes, then frees the event
- Rename WanMgr_DhcpClientEventsHandler_Thread to
  WanMgr_ProcessDhcpClientEvent (plain function, not thread entry)
- Remove DhcpClientEvents_mutex, pthread_detach/exit from handler
- Fix 'return NULL' in void functions Subscribe/UnSubscribe