### PR TITLE
RDKB-63810: Adding support for DHCP Release when DHCPManager is enabled

### DIFF
--- a/source/WanManager/wanmgr_net_utils.c
+++ b/source/WanManager/wanmgr_net_utils.c
@@ -577,8 +577,18 @@ ANSC_STATUS WanManager_StopDhcpv6Client(DML_VIRTUAL_IFACE* pVirtIf, DHCP_RELEASE
 
 #if  defined( FEATURE_RDKB_DHCP_MANAGER )
     char dmlName[256] = {0};
-    snprintf( dmlName, sizeof(dmlName), "%s.Enable", pVirtIf->IP.DHCPv6Iface );
-    if (ANSC_STATUS_SUCCESS == WanMgr_RdkBus_SetParamValues(DHCPMGR_COMPONENT_NAME, DHCPMGR_DBUS_PATH, dmlName, "false", ccsp_boolean, TRUE))
+    char dmlValue[16] = {0};
+    if(is_release_required == STOP_DHCP_WITH_RELEASE)
+    {
+        snprintf( dmlName, sizeof(dmlName), "%s.X_RDK_Release", pVirtIf->IP.DHCPv6Iface );
+        snprintf( dmlValue, sizeof(dmlValue), "%s", "true");
+    }
+    else
+    {
+        snprintf( dmlName, sizeof(dmlName), "%s.Enable", pVirtIf->IP.DHCPv6Iface );
+        snprintf( dmlValue, sizeof(dmlValue), "%s", "false");
+    }
+    if (ANSC_STATUS_SUCCESS == WanMgr_RdkBus_SetParamValues(DHCPMGR_COMPONENT_NAME, DHCPMGR_DBUS_PATH, dmlName, dmlValue, ccsp_boolean, TRUE))
     {
         CcspTraceInfo(("%s %d - Successfully set [%s] to DHCP Manager \n", __FUNCTION__, __LINE__, pVirtIf->Name));
         pVirtIf->IP.Dhcp6cStatus = DHCPC_STOPPED;
@@ -683,8 +693,18 @@ ANSC_STATUS WanManager_StopDhcpv4Client(DML_VIRTUAL_IFACE* pVirtIf, DHCP_RELEASE
     CcspTraceInfo (("%s %d: Stopping dhcpv4 client for %s %s\n", __FUNCTION__, __LINE__, pVirtIf->Name, (IsReleaseNeeded==STOP_DHCP_WITH_RELEASE)? "With release": "."));
 #if  defined( FEATURE_RDKB_DHCP_MANAGER )
     char dmlName[256] = {0};
-    snprintf( dmlName, sizeof(dmlName), "%s.Enable", pVirtIf->IP.DHCPv4Iface );
-    if (ANSC_STATUS_SUCCESS == WanMgr_RdkBus_SetParamValues(DHCPMGR_COMPONENT_NAME, DHCPMGR_DBUS_PATH, dmlName, "false", ccsp_boolean, TRUE))
+    char dmlValue[16] = {0};
+    if(IsReleaseNeeded == STOP_DHCP_WITH_RELEASE)
+    {        
+        snprintf( dmlName, sizeof(dmlName), "%s.X_RDK_Release", pVirtIf->IP.DHCPv4Iface );
+        snprintf( dmlValue, sizeof(dmlValue), "%s", "true");
+    }
+    else
+    {
+        snprintf( dmlName, sizeof(dmlName), "%s.Enable", pVirtIf->IP.DHCPv4Iface );
+        snprintf( dmlValue, sizeof(dmlValue), "%s", "false");
+    }
+    if (ANSC_STATUS_SUCCESS == WanMgr_RdkBus_SetParamValues(DHCPMGR_COMPONENT_NAME, DHCPMGR_DBUS_PATH, dmlName, dmlValue, ccsp_boolean, TRUE))
     {
         CcspTraceInfo(("%s %d - Successfully set [%s] to DHCP Manager \n", __FUNCTION__, __LINE__, pVirtIf->Name));
         pVirtIf->IP.Dhcp4cStatus = DHCPC_STOPPED;


### PR DESCRIPTION
RDKB-63810: CPE is sending DHCPv4/6 Releases in every FR/WAN refresh

Reason for change: CPE shouldn't send DHCPv4/6 Releases in every FR/WAN refresh
Test Procedure: provided Below
Risks: Low

Test the DHCPv6 RDKRelease(Device.DHCPv6.Client.1.X_RDK_Release) and collect the dibbler log and dhcpmanager log, also check DHPCManager sending release msg to wanmanager - Done
Test the DHCPv4 RDKRelease((Device.DHCPv4.Client.1.X_RDK_Release) ) and collect the udhcpc log and dhcpmaanger log, also check DHPCManager sending release msg to wanmanager - DONE
Test the RDK restart for DHCPv4(Device.DHCPv4.Client.1.X_RDK_Restart) and collect the udhcpc log and dhcpmaanger log
Test the RDK restart for DHCPv6 (Device.DHCPv6.Client.1.X_RDK_Restart) and collect the udhcpc log and dhcpmaanger log
Do Disable/Enable and check whether DHCPv4 and DHCPv6 release msg sent to WANMANAGER
(Device.DHCPv6.Client.1.Enable bool false), (Device.DHCPv6.Client.1.Enable bool true)
kill the udhcpc and dibbler-client with sigTERM(kill -TERM) and check whether DHCPv4 and DHCPv6 release msg sent to WANMANAGER