### PR TITLE
RDKB-63885: MAP-T missing TR-181 parameters parity

### DIFF
--- a/config/RdkWanManager_v2.xml
+++ b/config/RdkWanManager_v2.xml
@@ -1580,6 +1580,12 @@
            <writable>false</writable>
            </parameter>
            <parameter>
+           <name>X_RDKCENTRAL-COM_IPv4Address</name>
+           <type>string</type>
+           <syntax>string</syntax>
+           <writable>false</writable>
+           </parameter>
+           <parameter>
            <name>EABitsLength</name>
            <type>unsignedInt</type>
            <syntax>uint32</syntax>
@@ -1605,6 +1611,12 @@
            </parameter>
            <parameter>
            <name>PSID</name>
+           <type>unsignedInt</type>
+           <syntax>uint32</syntax>
+           <writable>false</writable>
+           </parameter>
+           <parameter>
+           <name>X_RDKCENTRAL-COM_Ratio</name>
            <type>unsignedInt</type>
            <syntax>uint32</syntax>
            <writable>false</writable>

--- a/source/TR-181/middle_layer_src/wanmgr_dml_map.c
+++ b/source/TR-181/middle_layer_src/wanmgr_dml_map.c
@@ -890,14 +890,12 @@ BOOL WanMapRule_GetParamStringValue(ANSC_HANDLE hInsContext, char* ParamName, ch
         return 0;
     }
 
-#ifdef FEATURE_MAPT
     if( AnscEqualString(ParamName, "X_RDKCENTRAL-COM_IPv4Address", TRUE))
     {
         /* collect value */
         AnscCopyString(pValue, pDomainRule->IPv4Address);
         return 0;
     }
-#endif
 
     return FALSE;
 }
@@ -1092,7 +1090,6 @@ BOOL WanMapRule_SetParamStringValue(ANSC_HANDLE hInsContext, char* ParamName, ch
         return TRUE;
     }
 
-#ifdef FEATURE_MAPT
     if( AnscEqualString(ParamName, "X_RDKCENTRAL-COM_IPv4Address", TRUE))
     {
         /* save update to backup */
@@ -1100,7 +1097,6 @@ BOOL WanMapRule_SetParamStringValue(ANSC_HANDLE hInsContext, char* ParamName, ch
 
         return TRUE;
     }
-#endif
 
     return FALSE;
 }

--- a/source/TR-181/middle_layer_src/wanmgr_dml_map.c
+++ b/source/TR-181/middle_layer_src/wanmgr_dml_map.c
@@ -814,6 +814,14 @@ BOOL WanMapRule_GetParamUlongValue(ANSC_HANDLE hInsContext, char* ParamName, ULO
          return TRUE;
     }
 
+    if( AnscEqualString(ParamName, "X_RDKCENTRAL-COM_Ratio", TRUE))
+    {
+        /* collect value */
+        *puLong = pDomainRule->Ratio;
+
+        return TRUE;
+    }
+
     return FALSE;
 }
 
@@ -881,6 +889,15 @@ BOOL WanMapRule_GetParamStringValue(ANSC_HANDLE hInsContext, char* ParamName, ch
         AnscCopyString(pValue, pDomainRule->IPv4Prefix);
         return 0;
     }
+
+#ifdef FEATURE_MAPT
+    if( AnscEqualString(ParamName, "X_RDKCENTRAL-COM_IPv4Address", TRUE))
+    {
+        /* collect value */
+        AnscCopyString(pValue, pDomainRule->IPv4Address);
+        return 0;
+    }
+#endif
 
     return FALSE;
 }
@@ -1003,6 +1020,14 @@ BOOL WanMapRule_SetParamUlongValue(ANSC_HANDLE hInsContext, char* ParamName, ULO
         return TRUE;
     }
 
+    if( AnscEqualString(ParamName, "X_RDKCENTRAL-COM_Ratio", TRUE))
+    {
+        /* save update to backup */
+        pDomainRule->Ratio = uValue;
+
+        return TRUE;
+    }
+
     return FALSE;
 }
 
@@ -1066,6 +1091,16 @@ BOOL WanMapRule_SetParamStringValue(ANSC_HANDLE hInsContext, char* ParamName, ch
 
         return TRUE;
     }
+
+#ifdef FEATURE_MAPT
+    if( AnscEqualString(ParamName, "X_RDKCENTRAL-COM_IPv4Address", TRUE))
+    {
+        /* save update to backup */
+        AnscCopyString(pDomainRule->IPv4Address, pString);
+
+        return TRUE;
+    }
+#endif
 
     return FALSE;
 }

--- a/source/TR-181/middle_layer_src/wanmgr_map_apis.c
+++ b/source/TR-181/middle_layer_src/wanmgr_map_apis.c
@@ -751,7 +751,13 @@ WanDmlMapDomGetRule_Data
         snprintf(pMapRule->Alias, sizeof(pMapRule->Alias), "Rule_%lu", ulIndex + 1);
         AnscCopyString(pMapRule->Origin, "DHCPv6");
         AnscCopyString(pMapRule->IPv6Prefix, pVirtIf->MAP.dhcp6cMAPparameters.ruleIPv6Prefix);
-        AnscCopyString(pMapRule->IPv4Prefix, pVirtIf->MAP.dhcp6cMAPparameters.ruleIPv4Prefix);
+        if (pVirtIf->MAP.dhcp6cMAPparameters.ruleIPv4Prefix[0] != '\0')
+        {
+            // fetch IPv4Prefix in CIDR format for TR-181
+            snprintf(pMapRule->IPv4Prefix, sizeof(pMapRule->IPv4Prefix), "%s/%u",
+                         pVirtIf->MAP.dhcp6cMAPparameters.ruleIPv4Prefix,
+                         pVirtIf->MAP.dhcp6cMAPparameters.v4Len);
+        }
 #ifdef FEATURE_MAPT
         AnscCopyString(pMapRule->IPv4Address, pVirtIf->MAP.MaptConfig.ipAddressString);
 #endif
@@ -774,9 +780,7 @@ WanDmlMapDomGetRule_Data
         AnscCopyString(pMapRule->Origin, "DHCPv6");
         pMapRule->IPv6Prefix[0] = '\0';
         pMapRule->IPv4Prefix[0] = '\0';
-#ifdef FEATURE_MAPT
         pMapRule->IPv4Address[0] = '\0';
-#endif
         pMapRule->EABitsLength = 0;
         pMapRule->IsFMR = 0;
         pMapRule->PSIDOffset = 0;
@@ -874,12 +878,10 @@ WanDmlMapDomSetRule
         AnscCopyString(pBuf_rule->IPv4Prefix, pEntry->IPv4Prefix);
     }
 
-#ifdef FEATURE_MAPT
     if (0 != strcmp(pEntry->IPv4Address, pBuf_rule->IPv4Address))
     {
         AnscCopyString(pBuf_rule->IPv4Address, pEntry->IPv4Address);
     }
-#endif
 
     if (pEntry->EABitsLength != pBuf_rule->EABitsLength)
     {

--- a/source/TR-181/middle_layer_src/wanmgr_map_apis.c
+++ b/source/TR-181/middle_layer_src/wanmgr_map_apis.c
@@ -752,12 +752,12 @@ WanDmlMapDomGetRule_Data
         AnscCopyString(pMapRule->Origin, "DHCPv6");
         AnscCopyString(pMapRule->IPv6Prefix, pVirtIf->MAP.dhcp6cMAPparameters.ruleIPv6Prefix);
         if (pVirtIf->MAP.dhcp6cMAPparameters.ruleIPv4Prefix[0] != '\0')
-        {
-            // fetch IPv4Prefix in CIDR format for TR-181
-            snprintf(pMapRule->IPv4Prefix, sizeof(pMapRule->IPv4Prefix), "%s/%u",
-                         pVirtIf->MAP.dhcp6cMAPparameters.ruleIPv4Prefix,
-                         pVirtIf->MAP.dhcp6cMAPparameters.v4Len);
-        }
+	{
+            // fetch IPv4Prefix in CIDR format for TR-181
+            snprintf(pMapRule->IPv4Prefix, sizeof(pMapRule->IPv4Prefix), "%s/%u",
+                         pVirtIf->MAP.dhcp6cMAPparameters.ruleIPv4Prefix,
+                         pVirtIf->MAP.dhcp6cMAPparameters.v4Len);
+        }
 #ifdef FEATURE_MAPT
         AnscCopyString(pMapRule->IPv4Address, pVirtIf->MAP.MaptConfig.ipAddressString);
 #endif

--- a/source/TR-181/middle_layer_src/wanmgr_map_apis.c
+++ b/source/TR-181/middle_layer_src/wanmgr_map_apis.c
@@ -752,12 +752,16 @@ WanDmlMapDomGetRule_Data
         AnscCopyString(pMapRule->Origin, "DHCPv6");
         AnscCopyString(pMapRule->IPv6Prefix, pVirtIf->MAP.dhcp6cMAPparameters.ruleIPv6Prefix);
         AnscCopyString(pMapRule->IPv4Prefix, pVirtIf->MAP.dhcp6cMAPparameters.ruleIPv4Prefix);
+#ifdef FEATURE_MAPT
+        AnscCopyString(pMapRule->IPv4Address, pVirtIf->MAP.MaptConfig.ipAddressString);
+#endif
 
         pMapRule->EABitsLength = pVirtIf->MAP.dhcp6cMAPparameters.eaLen;
         pMapRule->IsFMR = pVirtIf->MAP.dhcp6cMAPparameters.isFMR;
         pMapRule->PSIDOffset = pVirtIf->MAP.dhcp6cMAPparameters.psidOffset;
         pMapRule->PSIDLength = pVirtIf->MAP.dhcp6cMAPparameters.psidLen;
         pMapRule->PSID = pVirtIf->MAP.dhcp6cMAPparameters.psid;
+        pMapRule->Ratio = pVirtIf->MAP.dhcp6cMAPparameters.ratio;
         pMapRule->IncludeSystemPorts = FALSE;
     }
     else
@@ -770,11 +774,15 @@ WanDmlMapDomGetRule_Data
         AnscCopyString(pMapRule->Origin, "DHCPv6");
         pMapRule->IPv6Prefix[0] = '\0';
         pMapRule->IPv4Prefix[0] = '\0';
+#ifdef FEATURE_MAPT
+        pMapRule->IPv4Address[0] = '\0';
+#endif
         pMapRule->EABitsLength = 0;
         pMapRule->IsFMR = 0;
         pMapRule->PSIDOffset = 0;
         pMapRule->PSIDLength = 0;
         pMapRule->PSID = 0;
+        pMapRule->Ratio = 0;
         pMapRule->IncludeSystemPorts = FALSE;
     }
 
@@ -866,6 +874,13 @@ WanDmlMapDomSetRule
         AnscCopyString(pBuf_rule->IPv4Prefix, pEntry->IPv4Prefix);
     }
 
+#ifdef FEATURE_MAPT
+    if (0 != strcmp(pEntry->IPv4Address, pBuf_rule->IPv4Address))
+    {
+        AnscCopyString(pBuf_rule->IPv4Address, pEntry->IPv4Address);
+    }
+#endif
+
     if (pEntry->EABitsLength != pBuf_rule->EABitsLength)
     {
         pBuf_rule->EABitsLength = pEntry->EABitsLength;
@@ -889,6 +904,11 @@ WanDmlMapDomSetRule
     if (pEntry->PSID != pBuf_rule->PSID)
     {
         pBuf_rule->PSID = pEntry->PSID;
+    }
+
+    if (pEntry->Ratio != pBuf_rule->Ratio)
+    {
+        pBuf_rule->Ratio = pEntry->Ratio;
     }
 
     if (pEntry->IncludeSystemPorts != pBuf_rule->IncludeSystemPorts)

--- a/source/TR-181/middle_layer_src/wanmgr_map_apis.h
+++ b/source/TR-181/middle_layer_src/wanmgr_map_apis.h
@@ -135,6 +135,7 @@ _WAN_DML_MAP_RULE
     WAN_DML_RULE_STATUS           Status;
     CHAR                          Alias[DML_BUFF_SIZE_32];
     CHAR                          Origin[DML_BUFF_SIZE_32];
+    CHAR                          IPv4Address[DML_BUFF_SIZE_64];
     CHAR                          IPv6Prefix[DML_BUFF_SIZE_64];
     CHAR                          IPv4Prefix[DML_BUFF_SIZE_64];
     UINT                          EABitsLength;
@@ -143,6 +144,7 @@ _WAN_DML_MAP_RULE
     UINT                          PSIDLength;
     UINT                          PSID;
     BOOL                          IncludeSystemPorts;
+    ULONG                         Ratio;
 }WAN_DML_MAP_RULE, *PWAN_DML_MAP_RULE;
 
 typedef  struct


### PR DESCRIPTION
### Root cause analysis ###

DHCP manager exports a set of MAP-T related TR-181 parameters that are being monitored by markers.
The markers always refer to Device.DHCPv6.Client.1. instance even though there are multiple client instances in the device.
Each device will have different client instance as active. So, the markers point to wrong models in some platforms.

To correct this, the markers need to be updated to point to a generic model which displays the active client's MAP-T details.
This is already exported by WAN manager's BBF TR-181 Device.MAP.Domain.1. model for most of the fields.
This PR adds support to export the missing TR-181 fields needed by the markers.

### Fix ###

- Custom models Device.MAP.Domain.1.Rule.1.X_RDKCENTRAL-COM_IPv4Address and Device.MAP.Domain.1.Rule.1.X_RDKCENTRAL-COM_Ratio are introduced 
- Corresponding getter and setter functions are updated
- MAP info structures are updated with WAN manager fields 
- IPv4 prefix value is corrected to return CIDR subnet/prefixLength format
- Reference: Here is the related DHCP manager PR link https://github.com/rdkcentral/dhcp-manager/pull/87

### Unit test ###

[map-t_map-e_new_objs_RDKB-63885.rtf](https://github.com/user-attachments/files/26156443/map-t_map-e_new_objs_RDKB-63885.rtf)
