### PR TITLE
RDKB-64484: Allow psid offset value 0 for MAPT config

### DIFF
--- a/source/WanManager/DHCPv6cMsgHandler/dhcpv6c_msg_apis.c
+++ b/source/WanManager/DHCPv6cMsgHandler/dhcpv6c_msg_apis.c
@@ -248,7 +248,7 @@ MAPT_LOG_INFO("<<<TRACE>>> Start : %p | End : %p", pStartBuf,pEndBuf);
                               // allowed PsidOffset values are 0 to 15
                               if (g_stMaptData.PsidOffset > 15)
                               {
-                                  MAPT_LOG_ERROR("Parsing OPTION_S46_PORT_PARAM: Received invalid PsidOffset :%d");
+                                  MAPT_LOG_ERROR("Parsing OPTION_S46_PORT_PARAM: Received invalid PsidOffset :%u", g_stMaptData.PsidOffset);
                                   return STATUS_FAILURE;
                               }
                               if ( !g_stMaptData.EaLen )

--- a/source/WanManager/DHCPv6cMsgHandler/dhcpv6c_msg_apis.c
+++ b/source/WanManager/DHCPv6cMsgHandler/dhcpv6c_msg_apis.c
@@ -259,6 +259,42 @@ MAPT_LOG_INFO("<<<TRACE>>> Start : %p | End : %p", pStartBuf,pEndBuf);
                               MAPT_LOG_INFO("<<<TRACE>>> g_stMaptData.PsidLen    : %u", g_stMaptData.PsidLen);
                               MAPT_LOG_INFO("<<<TRACE>>> g_stMaptData.PsidOffset : %u", g_stMaptData.PsidOffset);
                               MAPT_LOG_INFO("<<<TRACE>>> g_stMaptData.Ratio      : %u", g_stMaptData.Ratio);
+
+                              /* ------------------------------------------------------------------ */
+                              /* Reserved Port Range Validation (0–1023) */
+                              /* ------------------------------------------------------------------ */
+                              {
+                                  UINT8 psidoffset  = g_stMaptData.PsidOffset;
+                                  UINT8 psidLen = g_stMaptData.PsidLen;
+                                  UINT16 psid   = g_stMaptData.Psid;
+
+                                  /* Validate MAP-T bit allocation: psidLen + offset must fit within 16-bit port space
+                                   * to avoid negative shifts (m = 16 - (psidLen + offset)) and undefined behavior. 
+	                              */
+                                  if (psidLen <= 16 && (psidLen + psidoffset) <= 16)
+                                  {
+                                      UINT8 m = 16 - (psidLen + psidoffset);
+
+                                      /* Lowest possible port for this CE */
+                                      UINT32 min_port = (psid << m);
+
+                                      /* Highest port in first block */
+                                      UINT32 max_first_block = min_port + ((1 << m) - 1);
+
+                                      if (min_port < 1024 || max_first_block < 1024)
+                                      {
+                                          MAPT_LOG_ERROR(
+                                              "MAP-T WARNING: Reserved port usage detected! psid=%u psidLen=%u offset=%u min_port=%u max_port=%u",
+                                              psid, psidLen, psidoffset, min_port, max_first_block
+                                          );
+                                      }
+                                  }
+                                  else
+                                  {
+                                      MAPT_LOG_WARNING("MAP-T WARNING: Invalid MAP parameters! psidLen=%u offset=%u", psidLen, offset);
+                                  }
+                              }
+                              /* ------------------------------------------------------------------ */
                               MAPT_LOG_INFO("Parsing OPTION_S46_PORT_PARAM Successful.");
                          }
                          else

--- a/source/WanManager/DHCPv6cMsgHandler/dhcpv6c_msg_apis.c
+++ b/source/WanManager/DHCPv6cMsgHandler/dhcpv6c_msg_apis.c
@@ -241,7 +241,7 @@ MAPT_LOG_INFO("<<<TRACE>>> Start : %p | End : %p", pStartBuf,pEndBuf);
                               // allowed PsidOffset values are 0 to 15
                               if (g_stMaptData.PsidOffset > 15)
 							  {
-                                  MAPT_LOG_ERROR("Parsing OPTION_S46_PORT_PARAM: Received invalid PsidOffset :%d");
+                                  MAPT_LOG_ERROR("Parsing OPTION_S46_PORT_PARAM: Received invalid PsidOffset :%u", g_stMaptData.PsidOffset);
                                   return STATUS_FAILURE;
 							  }
 							  if ( !g_stMaptData.EaLen )

--- a/source/WanManager/DHCPv6cMsgHandler/dhcpv6c_msg_apis.c
+++ b/source/WanManager/DHCPv6cMsgHandler/dhcpv6c_msg_apis.c
@@ -216,8 +216,7 @@ MAPT_LOG_INFO("<<<TRACE>>> Start : %p | End : %p", pStartBuf,pEndBuf);
 
                g_stMaptData.Ratio = 1 << (g_stMaptData.EaLen -
                                                     (BUFLEN_32 - g_stMaptData.RuleIPv4PrefixLen));
-               /* RFC default */
-               g_stMaptData.PsidOffset = 6;
+
                MAPT_LOG_INFO("<<<TRACE>>> g_stMaptData.Ratio             : %u", g_stMaptData.Ratio);
                MAPT_LOG_INFO("<<<TRACE>>> bytesLeftOut                   : %u", bytesLeftOut);
                if ( bytesLeftOut > 0 )
@@ -235,11 +234,17 @@ MAPT_LOG_INFO("<<<TRACE>>> Start : %p | End : %p", pStartBuf,pEndBuf);
                          if ( uiSubOption == MAPT_OPTION_S46_PORT_PARAMS &&
                               uiSubOptionLen == 4 )
                          {
-                              g_stMaptData.PsidOffset  = (*(pCurOption += uiSubOptionLen))?
-                                                                 *pCurOption:6;
+                              pCurOption += uiSubOptionLen;
+                              g_stMaptData.PsidOffset  = *pCurOption;
                               g_stMaptData.PsidLen     = *++pCurOption;
 
-                              if ( !g_stMaptData.EaLen )
+                              // allowed PsidOffset values are 0 to 15
+                              if (g_stMaptData.PsidOffset > 15)
+							  {
+                                  MAPT_LOG_ERROR("Parsing OPTION_S46_PORT_PARAM: Received invalid PsidOffset :%d");
+                                  return STATUS_FAILURE;
+							  }
+							  if ( !g_stMaptData.EaLen )
                               {
                                    g_stMaptData.Ratio = 1 << g_stMaptData.PsidLen;
                               }

--- a/source/WanManager/DHCPv6cMsgHandler/dhcpv6c_msg_apis.c
+++ b/source/WanManager/DHCPv6cMsgHandler/dhcpv6c_msg_apis.c
@@ -240,11 +240,11 @@ MAPT_LOG_INFO("<<<TRACE>>> Start : %p | End : %p", pStartBuf,pEndBuf);
 
                               // allowed PsidOffset values are 0 to 15
                               if (g_stMaptData.PsidOffset > 15)
-							  {
-                                  MAPT_LOG_ERROR("Parsing OPTION_S46_PORT_PARAM: Received invalid PsidOffset :%u", g_stMaptData.PsidOffset);
+                              {
+                                  MAPT_LOG_ERROR("Parsing OPTION_S46_PORT_PARAM: Received invalid PsidOffset :%d");
                                   return STATUS_FAILURE;
-							  }
-							  if ( !g_stMaptData.EaLen )
+                              }
+                              if ( !g_stMaptData.EaLen )
                               {
                                    g_stMaptData.Ratio = 1 << g_stMaptData.PsidLen;
                               }

--- a/source/WanManager/DHCPv6cMsgHandler/dhcpv6c_msg_apis.c
+++ b/source/WanManager/DHCPv6cMsgHandler/dhcpv6c_msg_apis.c
@@ -274,8 +274,8 @@ MAPT_LOG_INFO("<<<TRACE>>> Start : %p | End : %p", pStartBuf,pEndBuf);
                                   if (psidLen <= 16 && (psidLen + psidoffset) <= 16)
                                   {
                                       UINT8 m = 16 - (psidLen + psidoffset);
-                                      UINT8 block_shift = 16 - offset;
-                                      UINT32 min_i = (offset == 0) ? 0 : 1;
+                                      UINT8 block_shift = 16 - psidoffset;
+                                      UINT32 min_i = (psidoffset == 0) ? 0 : 1;
 
                                       /* Lowest possible port for this CE */
                                       UINT32 min_port = (min_i << block_shift) + (psid << m);

--- a/source/WanManager/DHCPv6cMsgHandler/dhcpv6c_msg_apis.c
+++ b/source/WanManager/DHCPv6cMsgHandler/dhcpv6c_msg_apis.c
@@ -291,7 +291,7 @@ MAPT_LOG_INFO("<<<TRACE>>> Start : %p | End : %p", pStartBuf,pEndBuf);
                                   }
                                   else
                                   {
-                                      MAPT_LOG_WARNING("MAP-T WARNING: Invalid MAP parameters! psidLen=%u offset=%u", psidLen, offset);
+                                      MAPT_LOG_WARNING("MAP-T WARNING: Invalid MAP parameters! psidLen=%u offset=%u", psidLen, psidoffset);
                                   }
                               }
                               /* ------------------------------------------------------------------ */

--- a/source/WanManager/DHCPv6cMsgHandler/dhcpv6c_msg_apis.c
+++ b/source/WanManager/DHCPv6cMsgHandler/dhcpv6c_msg_apis.c
@@ -234,7 +234,7 @@ MAPT_LOG_INFO("<<<TRACE>>> Start : %p | End : %p", pStartBuf,pEndBuf);
                          if ( uiSubOption == MAPT_OPTION_S46_PORT_PARAMS &&
                               uiSubOptionLen == 4 )
                          {
-                              pCurOption += uiSubOptionLen;
+                              pCurOption += sizeof(COSA_DML_MAPT_OPTION);
                               g_stMaptData.PsidOffset  = *pCurOption;
                               g_stMaptData.PsidLen     = *++pCurOption;
 

--- a/source/WanManager/DHCPv6cMsgHandler/dhcpv6c_msg_apis.c
+++ b/source/WanManager/DHCPv6cMsgHandler/dhcpv6c_msg_apis.c
@@ -274,18 +274,17 @@ MAPT_LOG_INFO("<<<TRACE>>> Start : %p | End : %p", pStartBuf,pEndBuf);
                                   if (psidLen <= 16 && (psidLen + psidoffset) <= 16)
                                   {
                                       UINT8 m = 16 - (psidLen + psidoffset);
+                                      UINT8 block_shift = 16 - offset;
+                                      UINT32 min_i = (offset == 0) ? 0 : 1;
 
                                       /* Lowest possible port for this CE */
-                                      UINT32 min_port = (psid << m);
+                                      UINT32 min_port = (min_i << block_shift) + (psid << m);
 
-                                      /* Highest port in first block */
-                                      UINT32 max_first_block = min_port + ((1 << m) - 1);
-
-                                      if (min_port < 1024 || max_first_block < 1024)
+                                      if (min_port < 1024)
                                       {
                                           MAPT_LOG_ERROR(
-                                              "MAP-T WARNING: Reserved port usage detected! psid=%u psidLen=%u offset=%u min_port=%u max_port=%u",
-                                              psid, psidLen, psidoffset, min_port, max_first_block
+                                              "MAP-T WARNING: Reserved port usage detected! psid=%u psidLen=%u offset=%u min_port=%u",
+                                              psid, psidLen, psidoffset, min_port
                                           );
                                       }
                                   }

--- a/source/WanManager/DHCPv6cMsgHandler/dhcpv6c_msg_apis.c
+++ b/source/WanManager/DHCPv6cMsgHandler/dhcpv6c_msg_apis.c
@@ -251,6 +251,14 @@ MAPT_LOG_INFO("<<<TRACE>>> Start : %p | End : %p", pStartBuf,pEndBuf);
                                   MAPT_LOG_ERROR("Parsing OPTION_S46_PORT_PARAM: Received invalid PsidOffset :%u", g_stMaptData.PsidOffset);
                                   return STATUS_FAILURE;
                               }
+
+                              // allowed PsidOffset values are 0 to 16
+                              if (g_stMaptData.PsidLen > 16)
+                              {
+                                  MAPT_LOG_ERROR("Parsing OPTION_S46_PORT_PARAM: Received invalid PsidLen :%u", g_stMaptData.PsidLen);
+                                  return STATUS_FAILURE;
+                              }
+
                               if ( !g_stMaptData.EaLen )
                               {
                                    g_stMaptData.Ratio = 1 << g_stMaptData.PsidLen;
@@ -277,8 +285,12 @@ MAPT_LOG_INFO("<<<TRACE>>> Start : %p | End : %p", pStartBuf,pEndBuf);
 
                                   /* Validate MAP-T bit allocation: psidLen + offset must fit within 16-bit port space
                                    * to avoid negative shifts (m = 16 - (psidLen + offset)) and undefined behavior. 
+								   * Ideally the check should be 
+								   * "if (psidoffset < 16 && psidLen <= 16 && (psidoffset + psidLen)<= 16)"
+								   * but since we are already rejecting invalid psidLen / psidOffset earlier, 
+								   * we don't need to validate here.
 	                              */
-                                  if (psidLen <= 16 && (psidLen + psidoffset) <= 16)
+                                  if ((psidLen + psidoffset) <= 16)
                                   {
                                       UINT8 m = 16 - (psidLen + psidoffset);
                                       UINT8 block_shift = 16 - psidoffset;
@@ -289,8 +301,8 @@ MAPT_LOG_INFO("<<<TRACE>>> Start : %p | End : %p", pStartBuf,pEndBuf);
 
                                       if (min_port < 1024)
                                       {
-                                          MAPT_LOG_ERROR(
-                                              "MAP-T WARNING: Reserved port usage detected! psid=%u psidLen=%u offset=%u min_port=%u",
+                                          MAPT_LOG_WARNING(
+                                              "MAP-T WARNING: Privileged port usage detected! psid=%u psidLen=%u offset=%u min_port=%u",
                                               psid, psidLen, psidoffset, min_port
                                           );
                                       }

--- a/source/WanManager/DHCPv6cMsgHandler/dhcpv6c_msg_apis.c
+++ b/source/WanManager/DHCPv6cMsgHandler/dhcpv6c_msg_apis.c
@@ -252,7 +252,7 @@ MAPT_LOG_INFO("<<<TRACE>>> Start : %p | End : %p", pStartBuf,pEndBuf);
                                   return STATUS_FAILURE;
                               }
 
-                              // allowed PsidOffset values are 0 to 16
+                              // allowed PsidLen values are 0 to 16
                               if (g_stMaptData.PsidLen > 16)
                               {
                                   MAPT_LOG_ERROR("Parsing OPTION_S46_PORT_PARAM: Received invalid PsidLen :%u", g_stMaptData.PsidLen);

--- a/source/WanManager/DHCPv6cMsgHandler/dhcpv6c_msg_apis.c
+++ b/source/WanManager/DHCPv6cMsgHandler/dhcpv6c_msg_apis.c
@@ -217,6 +217,13 @@ MAPT_LOG_INFO("<<<TRACE>>> Start : %p | End : %p", pStartBuf,pEndBuf);
                g_stMaptData.Ratio = 1 << (g_stMaptData.EaLen -
                                                     (BUFLEN_32 - g_stMaptData.RuleIPv4PrefixLen));
 
+               /*
+                * RFC default for PSID offset applies when the optional
+                * S46 Port Params suboption is not present. Keep the default
+                * here and let the suboption parser overwrite it with the
+                * received value, including 0 when that is explicitly encoded.
+                */
+               g_stMaptData.PsidOffset = 6;
                MAPT_LOG_INFO("<<<TRACE>>> g_stMaptData.Ratio             : %u", g_stMaptData.Ratio);
                MAPT_LOG_INFO("<<<TRACE>>> bytesLeftOut                   : %u", bytesLeftOut);
                if ( bytesLeftOut > 0 )


### PR DESCRIPTION
RDKB-64484: Allow psid offset value 0 for MAPT configuration

Reason for change: Allow PSID Offset 0 to be configured and validate the psid len and psid offset as per spec 
Test Procedure: Verify the psid offset 0 is configured for MAPT when CE receives it from DHCPV6 Option95 (suboption 93) response 
Risks: Low
Priority:P1