### PR TITLE
RDKB-64759: PSID and PSIDLength BBF DM parameters returning zero value

### DIFF
--- a/source/TR-181/include/wanmgr_dml.h
+++ b/source/TR-181/include/wanmgr_dml.h
@@ -441,6 +441,7 @@ typedef struct
     BOOL mapeAssigned;     /**< Have we been assigned mape config ? */
     BOOL maptAssigned;     /**< Have we been assigned mapt config ? */
     BOOL isFMR;
+    BOOL isPSIDComputed;
 }MaptData_t;
 
 typedef struct _WANMGR_MAPT_CONFIG_DATA_

--- a/source/TR-181/middle_layer_src/wanmgr_map_apis.c
+++ b/source/TR-181/middle_layer_src/wanmgr_map_apis.c
@@ -765,8 +765,18 @@ WanDmlMapDomGetRule_Data
         pMapRule->EABitsLength = pVirtIf->MAP.dhcp6cMAPparameters.eaLen;
         pMapRule->IsFMR = pVirtIf->MAP.dhcp6cMAPparameters.isFMR;
         pMapRule->PSIDOffset = pVirtIf->MAP.dhcp6cMAPparameters.psidOffset;
-        pMapRule->PSIDLength = pVirtIf->MAP.dhcp6cMAPparameters.psidLen;
-        pMapRule->PSID = pVirtIf->MAP.dhcp6cMAPparameters.psid;
+
+        /* get computed PSID and PSID length values if received from dhcp6c */
+        if ((dhcp6cMAPTMsgBody->psidLen > 0) && (dhcp6cMAPTMsgBody->eaLen == 0))
+        {
+            pMapRule->PSIDLength = pVirtIf->MAP.MaptConfig.psidLen;
+            pMapRule->PSID = pVirtIf->MAP.MaptConfig.psidValue;
+        }
+        else
+        {
+            pMapRule->PSIDLength = pVirtIf->MAP.dhcp6cMAPparameters.psidLen;
+            pMapRule->PSID = pVirtIf->MAP.dhcp6cMAPparameters.psid;
+        }
         pMapRule->Ratio = pVirtIf->MAP.dhcp6cMAPparameters.ratio;
         pMapRule->IncludeSystemPorts = FALSE;
     }

--- a/source/TR-181/middle_layer_src/wanmgr_map_apis.c
+++ b/source/TR-181/middle_layer_src/wanmgr_map_apis.c
@@ -769,13 +769,13 @@ WanDmlMapDomGetRule_Data
         /* get computed PSID and PSID length values if received from dhcp6c */
         if ((dhcp6cMAPTMsgBody->psidLen > 0) && (dhcp6cMAPTMsgBody->eaLen == 0))
         {
-            pMapRule->PSIDLength = pVirtIf->MAP.MaptConfig.psidLen;
-            pMapRule->PSID = pVirtIf->MAP.MaptConfig.psidValue;
+            pMapRule->PSIDLength = pVirtIf->MAP.dhcp6cMAPparameters.psidLen;
+            pMapRule->PSID = pVirtIf->MAP.dhcp6cMAPparameters.psid;
         }
         else
         {
-            pMapRule->PSIDLength = pVirtIf->MAP.dhcp6cMAPparameters.psidLen;
-            pMapRule->PSID = pVirtIf->MAP.dhcp6cMAPparameters.psid;
+            pMapRule->PSIDLength = pVirtIf->MAP.MaptConfig.psidLen;
+            pMapRule->PSID = pVirtIf->MAP.MaptConfig.psidValue;
         }
         pMapRule->Ratio = pVirtIf->MAP.dhcp6cMAPparameters.ratio;
         pMapRule->IncludeSystemPorts = FALSE;

--- a/source/TR-181/middle_layer_src/wanmgr_map_apis.c
+++ b/source/TR-181/middle_layer_src/wanmgr_map_apis.c
@@ -774,8 +774,13 @@ WanDmlMapDomGetRule_Data
         }
         else
         {
+#ifdef FEATURE_MAPT
             pMapRule->PSIDLength = pVirtIf->MAP.MaptConfig.psidLen;
             pMapRule->PSID = pVirtIf->MAP.MaptConfig.psidValue;
+#else
+            pMapRule->PSIDLength = 0;
+            pMapRule->PSID = 0;
+#endif
         }
         pMapRule->Ratio = pVirtIf->MAP.dhcp6cMAPparameters.ratio;
         pMapRule->IncludeSystemPorts = FALSE;

--- a/source/TR-181/middle_layer_src/wanmgr_map_apis.c
+++ b/source/TR-181/middle_layer_src/wanmgr_map_apis.c
@@ -767,7 +767,7 @@ WanDmlMapDomGetRule_Data
         pMapRule->PSIDOffset = pVirtIf->MAP.dhcp6cMAPparameters.psidOffset;
 
         /* get computed PSID and PSID length values if received from dhcp6c */
-        if ((dhcp6cMAPTMsgBody->psidLen > 0) && (dhcp6cMAPTMsgBody->eaLen == 0))
+        if ((pVirtIf->MAP.dhcp6cMAPparameters.psidLen > 0) && (pVirtIf->MAP.dhcp6cMAPparameters.eaLen == 0))
         {
             pMapRule->PSIDLength = pVirtIf->MAP.dhcp6cMAPparameters.psidLen;
             pMapRule->PSID = pVirtIf->MAP.dhcp6cMAPparameters.psid;

--- a/source/TR-181/middle_layer_src/wanmgr_map_apis.c
+++ b/source/TR-181/middle_layer_src/wanmgr_map_apis.c
@@ -767,6 +767,13 @@ WanDmlMapDomGetRule_Data
         pMapRule->PSIDOffset = pVirtIf->MAP.dhcp6cMAPparameters.psidOffset;
         pMapRule->PSIDLength = pVirtIf->MAP.dhcp6cMAPparameters.psidLen;
         pMapRule->PSID = pVirtIf->MAP.dhcp6cMAPparameters.psid;
+#ifdef FEATURE_MAPT
+        if (pVirtIf->MAP.MaptConfig.isPSIDComputed)
+        {
+            pMapRule->PSIDLength = pVirtIf->MAP.MaptConfig.psidLen;
+            pMapRule->PSID = pVirtIf->MAP.MaptConfig.psid;
+        }
+#endif
         pMapRule->Ratio = pVirtIf->MAP.dhcp6cMAPparameters.ratio;
         pMapRule->IncludeSystemPorts = FALSE;
     }

--- a/source/TR-181/middle_layer_src/wanmgr_map_apis.c
+++ b/source/TR-181/middle_layer_src/wanmgr_map_apis.c
@@ -765,29 +765,8 @@ WanDmlMapDomGetRule_Data
         pMapRule->EABitsLength = pVirtIf->MAP.dhcp6cMAPparameters.eaLen;
         pMapRule->IsFMR = pVirtIf->MAP.dhcp6cMAPparameters.isFMR;
         pMapRule->PSIDOffset = pVirtIf->MAP.dhcp6cMAPparameters.psidOffset;
-
-        /*
-         * MAP-E computes and stores PSID/PSIDLength in dhcp6cMAPparameters even
-         * when EA bits are present.
-         * Use explicit PSID values from DHCPv6 only when psidLen is present and eaLen is 0;
-         * otherwise use the locally computed MAP-T PSID values from PD EA-bits, or 0 when unavailable.
-        */
-        if ((pVirtIf->MAP.MapeStatus && (pVirtIf->MAP.dhcp6cMAPparameters.psidLen > 0)) || 
-            ((pVirtIf->MAP.dhcp6cMAPparameters.psidLen > 0) && (pVirtIf->MAP.dhcp6cMAPparameters.eaLen == 0)))
-        {
-            pMapRule->PSIDLength = pVirtIf->MAP.dhcp6cMAPparameters.psidLen;
-            pMapRule->PSID = pVirtIf->MAP.dhcp6cMAPparameters.psid;
-        }
-        else
-        {
-#ifdef FEATURE_MAPT
-            pMapRule->PSIDLength = pVirtIf->MAP.MaptConfig.psidLen;
-            pMapRule->PSID = pVirtIf->MAP.MaptConfig.psidValue;
-#else
-            pMapRule->PSIDLength = 0;
-            pMapRule->PSID = 0;
-#endif
-        }
+        pMapRule->PSIDLength = pVirtIf->MAP.dhcp6cMAPparameters.psidLen;
+        pMapRule->PSID = pVirtIf->MAP.dhcp6cMAPparameters.psid;
         pMapRule->Ratio = pVirtIf->MAP.dhcp6cMAPparameters.ratio;
         pMapRule->IncludeSystemPorts = FALSE;
     }

--- a/source/TR-181/middle_layer_src/wanmgr_map_apis.c
+++ b/source/TR-181/middle_layer_src/wanmgr_map_apis.c
@@ -766,8 +766,14 @@ WanDmlMapDomGetRule_Data
         pMapRule->IsFMR = pVirtIf->MAP.dhcp6cMAPparameters.isFMR;
         pMapRule->PSIDOffset = pVirtIf->MAP.dhcp6cMAPparameters.psidOffset;
 
-        /* get computed PSID and PSID length values if received from dhcp6c */
-        if ((pVirtIf->MAP.dhcp6cMAPparameters.psidLen > 0) && (pVirtIf->MAP.dhcp6cMAPparameters.eaLen == 0))
+        /*
+         * MAP-E computes and stores PSID/PSIDLength in dhcp6cMAPparameters even
+         * when EA bits are present.
+         * Use explicit PSID values from DHCPv6 only when psidLen is present and eaLen is 0;
+         * otherwise use the locally computed MAP-T PSID values from PD EA-bits, or 0 when unavailable.
+        */
+        if ((pVirtIf->MAP.MapeStatus && (pVirtIf->MAP.dhcp6cMAPparameters.psidLen > 0)) || 
+            ((pVirtIf->MAP.dhcp6cMAPparameters.psidLen > 0) && (pVirtIf->MAP.dhcp6cMAPparameters.eaLen == 0)))
         {
             pMapRule->PSIDLength = pVirtIf->MAP.dhcp6cMAPparameters.psidLen;
             pMapRule->PSID = pVirtIf->MAP.dhcp6cMAPparameters.psid;

--- a/source/WanManager/wanmgr_net_utils.c
+++ b/source/WanManager/wanmgr_net_utils.c
@@ -918,22 +918,28 @@ ANSC_STATUS WanManager_VerifyMAPTConfiguration(ipc_map_data_t *dhcp6cMAPTMsgBody
     {
         ret = WanManager_CalculatePsidAndV4Index(dhcp6cMAPTMsgBody->pdIPv6Prefix, dhcp6cMAPTMsgBody->v6Len, dhcp6cMAPTMsgBody->iapdPrefixLen,
                 dhcp6cMAPTMsgBody->v4Len, &(MaptConfig->psidValue), &ipv4IndexValue, &(MaptConfig->psidLen));
-    }
 
-    if (ret != RETURN_OK)
-    {
-        CcspTraceError(("Error in calculating MAPT PSID value \n"));
+        if (ret != RETURN_OK)
+        {
+            CcspTraceError(("Error in calculating MAPT PSID value \n"));
 #ifdef FEATURE_MAPT_DEBUG
-        MaptInfo("Exiting MAPT configuration, MAPT will not be configured, error found in getting PSID value");
+            MaptInfo("Exiting MAPT configuration, MAPT will not be configured, error found in getting PSID value");
 #endif
-        CcspTraceNotice(("FEATURE_MAPT: MAP-T configuration failed\n"));
-        return ANSC_STATUS_FAILURE;
+            CcspTraceNotice(("FEATURE_MAPT: MAP-T configuration failed\n"));
+            return ANSC_STATUS_FAILURE;
+        }
+#ifdef FEATURE_MAPT_DEBUG
+        MaptInfo("--- MAP-T Computed Values - START ---");
+        MaptInfo("mapt: PSID Value: %d, ipv4IndexValue: %d", MaptConfig->psidValue, ipv4IndexValue);
+        MaptInfo("mapt: PSID Length: %d", MaptConfig->psidLen);
+#endif
+        /* Since the Device.MAP.Domain DM uses the rule data structure to return values, 
+         * we need to update the structure with the calculated values 
+         * so that it returns the correct values
+        */
+        dhcp6cMAPTMsgBody->psid = MaptConfig->psidValue;
+        dhcp6cMAPTMsgBody->psidLen = MaptConfig->psidLen;
     }
-#ifdef FEATURE_MAPT_DEBUG
-    MaptInfo("--- MAP-T Computed Values - START ---");
-    MaptInfo("mapt: PSID Value: %d, ipv4IndexValue: %d", MaptConfig->psidValue, ipv4IndexValue);
-    MaptInfo("mapt: PSID Length: %d", MaptConfig->psidLen);
-#endif
 
     inet_pton(AF_INET, dhcp6cMAPTMsgBody->ruleIPv4Prefix, &(result));
 

--- a/source/WanManager/wanmgr_net_utils.c
+++ b/source/WanManager/wanmgr_net_utils.c
@@ -913,6 +913,7 @@ ANSC_STATUS WanManager_VerifyMAPTConfiguration(ipc_map_data_t *dhcp6cMAPTMsgBody
         MaptInfo("Using psidLen value from dhcp6c options : %d", MaptConfig->psidLen);
         MaptInfo("Using psidOffset value from dhcp6c options : %d", dhcp6cMAPTMsgBody->psidOffset);
 #endif
+        MaptConfig->isPSIDComputed = FALSE;
     }
     else
     {
@@ -933,12 +934,7 @@ ANSC_STATUS WanManager_VerifyMAPTConfiguration(ipc_map_data_t *dhcp6cMAPTMsgBody
         MaptInfo("mapt: PSID Value: %d, ipv4IndexValue: %d", MaptConfig->psidValue, ipv4IndexValue);
         MaptInfo("mapt: PSID Length: %d", MaptConfig->psidLen);
 #endif
-        /* Since the Device.MAP.Domain DM uses the rule data structure to return values, 
-         * we need to update the structure with the calculated values 
-         * so that it returns the correct values
-        */
-        dhcp6cMAPTMsgBody->psid = MaptConfig->psidValue;
-        dhcp6cMAPTMsgBody->psidLen = MaptConfig->psidLen;
+        MaptConfig->isPSIDComputed = TRUE;
     }
 
     inet_pton(AF_INET, dhcp6cMAPTMsgBody->ruleIPv4Prefix, &(result));


### PR DESCRIPTION
RDKB-64759: PSID and PSIDLength BBF DM parameters returning zero value

Reason for change: Use computed PSID and PSID length values from PD when eaLen is greater than 0 from the received option95 MAP rule data. 
Test Procedure: Verify the PSIDLength  and PSID parameters of Device.MAP.Domain. DM return proper values as per configured MAPT settings.
Risks: Low
Priority: P2
