### PR TITLE
RDKCOM-5584: RDKBDEV-3439 Prevent duplicate IPv6 assignment on brlan0 by removing redundant lan-restart sysevent handling in setUpLanPrefixIPv6().

### DIFF
--- a/source/WanManager/wanmgr_dhcpv6_apis.c
+++ b/source/WanManager/wanmgr_dhcpv6_apis.c
@@ -2134,8 +2134,6 @@ int setUpLanPrefixIPv6(DML_VIRTUAL_IFACE* pVirtIf)
     /* This is for IP.Interface.1. use */
     sysevent_set(sysevent_fd, sysevent_token, COSA_DML_DHCPV6S_ADDR_SYSEVENT_NAME, globalIP, 0);
 
-    CcspTraceWarning(("%s: setting lan-restart\n", __FUNCTION__));
-    sysevent_set(sysevent_fd, sysevent_token, "lan-restart", "1", 0);
 #if defined(CISCO_CONFIG_DHCPV6_PREFIX_DELEGATION) && ! defined(DHCPV6_PREFIX_FIX) 
     CcspTraceWarning(("%s: setting dhcpv6_server-restart\n", __FUNCTION__));
     sysevent_set(sysevent_fd, sysevent_token, "dhcpv6_server-restart", "", 0);


### PR DESCRIPTION
Reason For Change: Setting the lan-restart sysevent triggers IPv6 address assignment on brlan0. Since WANManager already handles brlan0 IPv6 assignment earlier in setUpLanPrefixIPv6(), setting this sysevent again later in the function is unnecessary and causes duplicate assignment. To avoid repetition and stale configuration, the lan-restart sysevent update has been removed from the later part of the function.

Risks: Low
Signed-off-by: Aiswarya Prasad <aprasad@maxlinear.com>