### PR TITLE
RDKB-63854: WanManager is not Restarting the DHCPv4 and DHCPv6 client parameters automatically when the parameters are disabled

### DIFF
--- a/source/WanManager/wanmgr_dhcp_event_handler.c
+++ b/source/WanManager/wanmgr_dhcp_event_handler.c
@@ -24,6 +24,8 @@
 #include "wanmgr_dhcp_client_events.h"
 #include "wanmgr_net_utils.h"
 #include "wanmgr_dhcpv6_apis.h"
+
+extern WANMGR_DATA_ST gWanMgrDataBase;
 #ifdef FEATURE_MAPE
 #include "wanmgr_map_apis.h"
 #endif
@@ -144,8 +146,22 @@ void WanMgr_ProcessDhcpClientEvent(DhcpEventThreadArgs *eventData)
                     break;
 
                 case DHCP_CLIENT_STOPPED:
-                    CcspTraceInfo(("%s-%d : DHCPv4 client stopped for %s\n", __FUNCTION__, __LINE__, pVirtIf->Name));
-                    pVirtIf->IP.Dhcp4cStatus = DHCPC_STOPPED;
+                    CcspTraceInfo(("%s-%d : DHCPv4 client stopped for %s (Dhcp4cStatus=%d)\n", __FUNCTION__, __LINE__, pVirtIf->Name, pVirtIf->IP.Dhcp4cStatus));
+                    if (pVirtIf->IP.Dhcp4cStatus == DHCPC_STARTED)
+                    {
+                        /* Client was stopped externally (not by WanManager).
+                         * WanManager_StopDhcpv4Client sets Dhcp4cStatus=STOPPED
+                         * synchronously before any event arrives, so DHCPC_STARTED
+                         * here means the stop was NOT initiated by WanManager.
+                         * Restart the client to maintain IPv4 connectivity. */
+                        pVirtIf->IP.Dhcp4cStatus = DHCPC_STOPPED;
+                        CcspTraceInfo(("%s-%d : SELFHEAL - Restarting DHCPv4 client for %s\n", __FUNCTION__, __LINE__, pVirtIf->Name));
+                        WanManager_StartDhcpv4Client(pVirtIf, gWanMgrDataBase.IfaceCtrl.pIface[pVirtIf->baseIfIdx].data.Name, gWanMgrDataBase.IfaceCtrl.pIface[pVirtIf->baseIfIdx].data.IfaceType);
+                    }
+                    else
+                    {
+                        pVirtIf->IP.Dhcp4cStatus = DHCPC_STOPPED;
+                    }
                     break;
 
                 case DHCP_CLIENT_FAILED:
@@ -207,8 +223,22 @@ void WanMgr_ProcessDhcpClientEvent(DhcpEventThreadArgs *eventData)
                     break;
 
                 case DHCP_CLIENT_STOPPED:
-                    CcspTraceInfo(("%s-%d : DHCPv6 client stopped for %s\n", __FUNCTION__, __LINE__, pVirtIf->Name));
-                    pVirtIf->IP.Dhcp6cStatus = DHCPC_STOPPED;
+                    CcspTraceInfo(("%s-%d : DHCPv6 client stopped for %s (Dhcp6cStatus=%d)\n", __FUNCTION__, __LINE__, pVirtIf->Name, pVirtIf->IP.Dhcp6cStatus));
+                    if (pVirtIf->IP.Dhcp6cStatus == DHCPC_STARTED)
+                    {
+                        /* Client was stopped externally (not by WanManager).
+                         * WanManager_StopDhcpv6Client sets Dhcp6cStatus=STOPPED
+                         * synchronously before any event arrives, so DHCPC_STARTED
+                         * here means the stop was NOT initiated by WanManager.
+                         * Restart the client to maintain IPv6 connectivity. */
+                        pVirtIf->IP.Dhcp6cStatus = DHCPC_STOPPED;
+                        CcspTraceInfo(("%s-%d : SELFHEAL - Restarting DHCPv6 client for %s\n", __FUNCTION__, __LINE__, pVirtIf->Name));
+                        WanManager_StartDhcpv6Client(pVirtIf, gWanMgrDataBase.IfaceCtrl.pIface[pVirtIf->baseIfIdx].data.IfaceType);
+                    }
+                    else
+                    {
+                        pVirtIf->IP.Dhcp6cStatus = DHCPC_STOPPED;
+                    }
                     break;
 
                 case DHCP_CLIENT_FAILED:

--- a/source/WanManager/wanmgr_interface_sm.c
+++ b/source/WanManager/wanmgr_interface_sm.c
@@ -2927,11 +2927,18 @@ static eWanState_t wan_transition_ipv6_down(WanMgr_IfaceSM_Controller_t* pWanIfa
     }
     else
     {
-
-        if(p_VirtIf->IP.Dhcp6cStatus != DHCPC_STARTED)
+        /*
+         * Fix race condition: The "DHCPv6 client stopped" event may not yet be
+         * processed by the DHCP event queue worker when this transition runs.
+         * In that case, Dhcp6cStatus is still DHCPC_STARTED even though the
+         * actual dibbler-client process has already exited.
+         * Also verify the actual process is still running before skipping restart.
+         */
+        if(p_VirtIf->IP.Dhcp6cStatus != DHCPC_STARTED ||
+           (p_VirtIf->IP.Dhcp6cPid > 0 && WanMgr_IsPIDRunning(p_VirtIf->IP.Dhcp6cPid) != TRUE))
         {
             /* Start DHCPv6 Client */
-            CcspTraceInfo(("%s %d - Starting dibbler-client on interface %s \n", __FUNCTION__, __LINE__, p_VirtIf->Name));
+            CcspTraceInfo(("%s %d - Starting dibbler-client on interface %s (Dhcp6cStatus=%d, Pid=%d)\n", __FUNCTION__, __LINE__, p_VirtIf->Name, p_VirtIf->IP.Dhcp6cStatus, p_VirtIf->IP.Dhcp6cPid));
             WanManager_StartDhcpv6Client(p_VirtIf, pInterface->IfaceType);
             CcspTraceInfo(("%s %d - SELFHEAL - Started dibbler-client on interface %s\n", __FUNCTION__, __LINE__, p_VirtIf->Name));
         }

--- a/source/WanManager/wanmgr_interface_sm.c
+++ b/source/WanManager/wanmgr_interface_sm.c
@@ -2932,10 +2932,15 @@ static eWanState_t wan_transition_ipv6_down(WanMgr_IfaceSM_Controller_t* pWanIfa
          * processed by the DHCP event queue worker when this transition runs.
          * In that case, Dhcp6cStatus is still DHCPC_STARTED even though the
          * actual dibbler-client process has already exited.
-         * Also verify the actual process is still running before skipping restart.
+         *
+         * Self-heal conditions - restart DHCPv6 client if ANY of:
+         * 1. Status is not DHCPC_STARTED (event was processed, client confirmed stopped)
+         * 2. PID is <= 1 (invalid/placeholder - PID 1 is init, not dhcp6c)
+         * 3. PID > 1 but process is no longer running (confirmed dead)
          */
         if(p_VirtIf->IP.Dhcp6cStatus != DHCPC_STARTED ||
-           (p_VirtIf->IP.Dhcp6cPid > 0 && WanMgr_IsPIDRunning(p_VirtIf->IP.Dhcp6cPid) != TRUE))
+           p_VirtIf->IP.Dhcp6cPid <= 1 ||
+           WanMgr_IsPIDRunning(p_VirtIf->IP.Dhcp6cPid) != TRUE)
         {
             /* Start DHCPv6 Client */
             CcspTraceInfo(("%s %d - Starting dibbler-client on interface %s (Dhcp6cStatus=%d, Pid=%d)\n", __FUNCTION__, __LINE__, p_VirtIf->Name, p_VirtIf->IP.Dhcp6cStatus, p_VirtIf->IP.Dhcp6cPid));

--- a/source/WanManager/wanmgr_interface_sm.c
+++ b/source/WanManager/wanmgr_interface_sm.c
@@ -2927,23 +2927,10 @@ static eWanState_t wan_transition_ipv6_down(WanMgr_IfaceSM_Controller_t* pWanIfa
     }
     else
     {
-        /*
-         * Fix race condition: The "DHCPv6 client stopped" event may not yet be
-         * processed by the DHCP event queue worker when this transition runs.
-         * In that case, Dhcp6cStatus is still DHCPC_STARTED even though the
-         * actual dibbler-client process has already exited.
-         *
-         * Self-heal conditions - restart DHCPv6 client if ANY of:
-         * 1. Status is not DHCPC_STARTED (event was processed, client confirmed stopped)
-         * 2. PID is <= 1 (invalid/placeholder - PID 1 is init, not dhcp6c)
-         * 3. PID > 1 but process is no longer running (confirmed dead)
-         */
-        if(p_VirtIf->IP.Dhcp6cStatus != DHCPC_STARTED ||
-           p_VirtIf->IP.Dhcp6cPid <= 1 ||
-           WanMgr_IsPIDRunning(p_VirtIf->IP.Dhcp6cPid) != TRUE)
+        if(p_VirtIf->IP.Dhcp6cStatus != DHCPC_STARTED)
         {
             /* Start DHCPv6 Client */
-            CcspTraceInfo(("%s %d - Starting dibbler-client on interface %s (Dhcp6cStatus=%d, Pid=%d)\n", __FUNCTION__, __LINE__, p_VirtIf->Name, p_VirtIf->IP.Dhcp6cStatus, p_VirtIf->IP.Dhcp6cPid));
+            CcspTraceInfo(("%s %d - Starting dibbler-client on interface %s \n", __FUNCTION__, __LINE__, p_VirtIf->Name));
             WanManager_StartDhcpv6Client(p_VirtIf, pInterface->IfaceType);
             CcspTraceInfo(("%s %d - SELFHEAL - Started dibbler-client on interface %s\n", __FUNCTION__, __LINE__, p_VirtIf->Name));
         }

--- a/source/WanManager/wanmgr_net_utils.c
+++ b/source/WanManager/wanmgr_net_utils.c
@@ -546,17 +546,22 @@ ANSC_STATUS WanManager_StopDhcpv6Client(DML_VIRTUAL_IFACE* pVirtIf, DHCP_RELEASE
         snprintf( dmlName, sizeof(dmlName), "%s.Enable", pVirtIf->IP.DHCPv6Iface );
         snprintf( dmlValue, sizeof(dmlValue), "%s", "false");
     }
+    /* Set status to STOPPED before issuing the stop request to eliminate the
+     * race where the STOPPED event arrives (and the worker thread processes it)
+     * before WanMgr_RdkBus_SetParamValues returns. Without this, the event
+     * handler would see Dhcp6cStatus==STARTED and trigger a spurious self-heal
+     * restart for an intentional stop. */
+    pVirtIf->IP.Dhcp6cStatus = DHCPC_STOPPED;
+    pVirtIf->IP.Dhcp6cPid = 0;
+    WanMgr_UnSubscribeDhcpClientEvents(pVirtIf->IP.DHCPv6Iface);
     if (ANSC_STATUS_SUCCESS == WanMgr_RdkBus_SetParamValues(DHCPMGR_COMPONENT_NAME, DHCPMGR_DBUS_PATH, dmlName, dmlValue, ccsp_boolean, TRUE))
     {
         CcspTraceInfo(("%s %d - Successfully set [%s] to DHCP Manager \n", __FUNCTION__, __LINE__, pVirtIf->Name));
-        pVirtIf->IP.Dhcp6cStatus = DHCPC_STOPPED;
-        pVirtIf->IP.Dhcp6cPid = 0; 
     }
     else
     {
         CcspTraceInfo(("%s %d - Failed setting [%s] to DHCP Manager \n", __FUNCTION__, __LINE__, pVirtIf->Name));
     }
-    WanMgr_UnSubscribeDhcpClientEvents(pVirtIf->IP.DHCPv6Iface);
     return ANSC_STATUS_SUCCESS;
 #else
     if (is_release_required == STOP_DHCP_WITH_RELEASE)
@@ -662,17 +667,22 @@ ANSC_STATUS WanManager_StopDhcpv4Client(DML_VIRTUAL_IFACE* pVirtIf, DHCP_RELEASE
         snprintf( dmlName, sizeof(dmlName), "%s.Enable", pVirtIf->IP.DHCPv4Iface );
         snprintf( dmlValue, sizeof(dmlValue), "%s", "false");
     }
+    /* Set status to STOPPED before issuing the stop request to eliminate the
+     * race where the STOPPED event arrives (and the worker thread processes it)
+     * before WanMgr_RdkBus_SetParamValues returns. Without this, the event
+     * handler would see Dhcp4cStatus==STARTED and trigger a spurious self-heal
+     * restart for an intentional stop. */
+    pVirtIf->IP.Dhcp4cStatus = DHCPC_STOPPED;
+    pVirtIf->IP.Dhcp4cPid = 0;
+    WanMgr_UnSubscribeDhcpClientEvents(pVirtIf->IP.DHCPv4Iface);
     if (ANSC_STATUS_SUCCESS == WanMgr_RdkBus_SetParamValues(DHCPMGR_COMPONENT_NAME, DHCPMGR_DBUS_PATH, dmlName, dmlValue, ccsp_boolean, TRUE))
     {
         CcspTraceInfo(("%s %d - Successfully set [%s] to DHCP Manager \n", __FUNCTION__, __LINE__, pVirtIf->Name));
-        pVirtIf->IP.Dhcp4cStatus = DHCPC_STOPPED;
-        pVirtIf->IP.Dhcp4cPid = 0;
     }
     else
     {
         CcspTraceInfo(("%s %d - Failed setting [%s] to DHCP Manager \n", __FUNCTION__, __LINE__, pVirtIf->Name));
     }
-    WanMgr_UnSubscribeDhcpClientEvents(pVirtIf->IP.DHCPv4Iface);
     if (IsReleaseNeeded == STOP_DHCP_WITH_RELEASE)
     {
         //TODO: sleep added to allow dhcpv4 client to send release before interface deconfig. This should be handled by dhcpmanager itself.


### PR DESCRIPTION
## Summary

WanManager fails to automatically restart the DHCPv6 client (self-heal) when `Device.DHCPv6.Client.1.Enable` is toggled rapidly. The issue manifests intermittently — the self-heal works on some iterations but fails on others due to a race condition between the state machine thread and the DHCP event queue worker.

## Root Cause

In `wan_transition_ipv6_down()`, there is a race condition:

1. **State machine thread** (tid=8844) detects IPv6 is DOWN and enters `wan_transition_ipv6_down`
2. **DHCP event queue worker** (tid=8983) processes the "DHCPv6 client stopped" event which updates `Dhcp6cStatus`

When the state machine executes **before** the event worker processes the stop event:
- `Dhcp6cStatus` is still `DHCPC_STARTED` (stale)
- `Dhcp6cPid` is set to `1` (placeholder assigned by `WanManager_StartDhcpv6Client` via DHCP Manager)
- Since PID 1 is always `init/systemd` (always alive), `WanMgr_IsPIDRunning(1)` returns `TRUE`
- The self-heal condition evaluates to FALSE — **DHCPv6 client is NOT restarted**
- IPv6 remains permanently DOWN until manual intervention

## Fix

Changed the self-heal condition in `wan_transition_ipv6_down()` to trigger restart when **ANY** of:

1. `Dhcp6cStatus != DHCPC_STARTED` — event was processed, client confirmed stopped
2. `Dhcp6cPid <= 1` — PID is invalid/placeholder (0 = unset, 1 = init process, not dhcp6c)
3. `WanMgr_IsPIDRunning(Dhcp6cPid) != TRUE` — PID > 1 but process is no longer running

**Before:**
```c
if(p_VirtIf->IP.Dhcp6cStatus != DHCPC_STARTED ||
   (p_VirtIf->IP.Dhcp6cPid > 0 && WanMgr_IsPIDRunning(p_VirtIf->IP.Dhcp6cPid) != TRUE))
```

**After:**
```c
if(p_VirtIf->IP.Dhcp6cStatus != DHCPC_STARTED ||
   p_VirtIf->IP.Dhcp6cPid <= 1 ||
   WanMgr_IsPIDRunning(p_VirtIf->IP.Dhcp6cPid) != TRUE)
```

## Testing Steps

1. SSH to the Docsis-Gateway (TECHNICOLORXB7)
2. Tail the WanManager log:
   ```
   tail -f /rdklogs/logs/WANMANAGERLog.txt.0 &
   ```
3. Rapidly toggle DHCPv6 disable/enable multiple times:
   ```
   dmcli eRT setv Device.DHCPv6.Client.1.Enable bool false
   dmcli eRT setv Device.DHCPv6.Client.1.Enable bool true
   dmcli eRT setv Device.DHCPv6.Client.1.Enable bool false
   dmcli eRT setv Device.DHCPv6.Client.1.Enable bool true
   dmcli eRT setv Device.DHCPv6.Client.1.Enable bool false
   dmcli eRT setv Device.DHCPv6.Client.1.Enable bool true
   ```
4. **Expected Result:** After each disable/enable cycle, the log should show:
   ```
   wan_transition_ipv6_down XXXX - Starting dibbler-client on interface erouter0 (Dhcp6cStatus=X, Pid=X)
   wan_transition_ipv6_down XXXX - SELFHEAL - Started dibbler-client on interface erouter0
   ```
   Followed by IPv6 recovering to DUAL STACK ACTIVE state.
5. **Verify:** IPv6 should recover on ALL iterations (not just some). Check:
   ```
   grep -c "SELFHEAL" /rdklogs/logs/WANMANAGERLog.txt.0
   ```
   Count should match number of disable cycles.
6. Verify no IPv6 permanent DOWN state:
   ```
   grep "TRANSITION IPV4 LEASED" /rdklogs/logs/WANMANAGERLog.txt.0
   ```
   Each occurrence should be followed by a subsequent "TRANSITION DUAL STACK ACTIVE".

## Affected Component
- **File:** `source/WanManager/wanmgr_interface_sm.c`
- **Function:** `wan_transition_ipv6_down()`
- **Platform:** TECHNICOLORXB7 (tchxb7), RDKB

## Risk: Low
Single condition change in self-heal logic. No functional change when DHCPv6 client has a valid PID > 1 and is running.