### PR TITLE
RDKCOM-5595: RDKBDEV-3450 The CM is not updated with DNS Name (Option15), instead utopia.net is displayed in LAN side provisioning.

### DIFF
--- a/source/TR-181/include/wanmgr_dml.h
+++ b/source/TR-181/include/wanmgr_dml.h
@@ -338,6 +338,7 @@ typedef struct _WANMGR_IPV4_DATA
     char gateway[BUFLEN_32];           /** New gateway, if addressAssigned==TRUE */
     char dnsServer[BUFLEN_64];         /** New dns Server, if addressAssigned==TRUE */
     char dnsServer1[BUFLEN_64];        /** New dns Server, if addressAssigned==TRUE */
+    char domain[BUFLEN_64];            /** New domain name, if addressAssigned==TRUE */
     uint32_t mtuSize;                  /** New MTU size, if mtuAssigned==TRUE */
     uint32_t leaseReceivedTime;        /** Lease received time*/
 #if defined(FEATURE_RDKB_CONFIGURABLE_WAN_INTERFACE)

--- a/source/WanManager/wanmgr_dhcpv4_apis.c
+++ b/source/WanManager/wanmgr_dhcpv4_apis.c
@@ -83,6 +83,7 @@ static ANSC_STATUS wanmgr_dchpv4_get_ipc_msg_info(WANMGR_IPV4_DATA* pDhcpv4Data,
     memcpy(pDhcpv4Data->gateway, pIpcIpv4Data->gateway, BUFLEN_32);
     memcpy(pDhcpv4Data->dnsServer, pIpcIpv4Data->dnsServer, BUFLEN_64);
     memcpy(pDhcpv4Data->dnsServer1, pIpcIpv4Data->dnsServer1, BUFLEN_64);
+    snprintf(pDhcpv4Data->domain, sizeof(pDhcpv4Data->domain), "%s", pIpcIpv4Data->domain);
 #if defined(FEATURE_RDKB_CONFIGURABLE_WAN_INTERFACE)
     memcpy(pDhcpv4Data->timeZone, pIpcIpv4Data->timeZone, BUFLEN_64);
     pDhcpv4Data->isTimeOffsetAssigned = pIpcIpv4Data->isTimeOffsetAssigned;
@@ -146,6 +147,7 @@ ANSC_STATUS wanmgr_handle_dhcpv4_event_data(DML_VIRTUAL_IFACE* pVirtIf)
     if (strcmp(pVirtIf->IP.Ipv4Data.ip, pDhcpcInfo->ip) ||
       strcmp(pVirtIf->IP.Ipv4Data.mask, pDhcpcInfo->mask) ||
       strcmp(pVirtIf->IP.Ipv4Data.gateway, pDhcpcInfo->gateway) ||
+      strcmp(pVirtIf->IP.Ipv4Data.domain, pDhcpcInfo->domain) ||
       strcmp(pVirtIf->IP.Ipv4Data.dnsServer, pDhcpcInfo->dnsServer) ||
       strcmp(pVirtIf->IP.Ipv4Data.dnsServer1, pDhcpcInfo->dnsServer1))
     {
@@ -167,10 +169,11 @@ ANSC_STATUS wanmgr_handle_dhcpv4_event_data(DML_VIRTUAL_IFACE* pVirtIf)
 
     if (pDhcpcInfo->addressAssigned)
     {
-        CcspTraceInfo(("assigned ip=%s netmask=%s gateway=%s dns server=%s,%s leasetime = %d, rebindtime = %d, renewaltime = %d, dhcp state = %s mtu = %d\n",
+        CcspTraceInfo(("assigned ip=%s netmask=%s gateway=%s domain=%s dns server=%s,%s leasetime = %d, rebindtime = %d, renewaltime = %d, dhcp state = %s mtu = %d\n",
                      pDhcpcInfo->ip,
                      pDhcpcInfo->mask,
                      pDhcpcInfo->gateway,
+                     pDhcpcInfo->domain,
                      pDhcpcInfo->dnsServer,
                      pDhcpcInfo->dnsServer1,
                      pDhcpcInfo->leaseTime,

--- a/source/WanManager/wanmgr_interface_sm.c
+++ b/source/WanManager/wanmgr_interface_sm.c
@@ -820,6 +820,8 @@ int wan_updateDNS(WanMgr_IfaceSM_Controller_t* pWanIfaceCtrl, BOOL addIPv4, BOOL
     char v6nameserver1[BUFLEN_128];
     char v6nameserver2[BUFLEN_128]; 
     bool resolv_conf_changed = FALSE;
+    char currentDomain[BUFLEN_64] = {0};
+    char desiredDomain[BUFLEN_64] = {0};
 
     if (deviceMode == GATEWAY_MODE)
     {
@@ -836,8 +838,12 @@ int wan_updateDNS(WanMgr_IfaceSM_Controller_t* pWanIfaceCtrl, BOOL addIPv4, BOOL
     sysevent_get(sysevent_fd, sysevent_token, SYSEVENT_FIELD_IPV6_DNS_PRIMARY, v6nameserver1, sizeof(v6nameserver1));
     sysevent_get(sysevent_fd, sysevent_token, SYSEVENT_FIELD_IPV6_DNS_SECONDARY, v6nameserver2, sizeof(v6nameserver2));
 
+    // save current domain name
+    sysevent_get(sysevent_fd, sysevent_token, SYSEVENT_IPV4_DOMAIN, currentDomain, sizeof(currentDomain));
+
     CcspTraceInfo(("%s %d: v4nameserver1 = %s v4nameserver2 = %s\n", __FUNCTION__, __LINE__, v4nameserver1, v4nameserver2));
     CcspTraceInfo(("%s %d: v6nameserver1 = %s v6nameserver2 = %s\n", __FUNCTION__, __LINE__, v6nameserver1, v6nameserver2));
+    CcspTraceInfo(("%s %d: current domain name = %s\n", __FUNCTION__, __LINE__, currentDomain));
 
     if (addIPv4 == FALSE && addIPv6 == FALSE)
     {
@@ -861,6 +867,10 @@ int wan_updateDNS(WanMgr_IfaceSM_Controller_t* pWanIfaceCtrl, BOOL addIPv4, BOOL
             fclose(fp);
             Update_Interface_Status();
         }
+
+        // clear domain name sysevent
+        sysevent_set(sysevent_fd, sysevent_token, SYSEVENT_IPV4_DOMAIN, "", 0);
+
         // new and curr nameservers are different, so apply configuration
         CcspTraceInfo(("%s %d: Setting %s\n", __FUNCTION__, __LINE__, SYSEVENT_DHCP_SERVER_RESTART));
         sysevent_set(sysevent_fd, sysevent_token, SYSEVENT_DHCP_SERVER_RESTART, NULL, 0);
@@ -983,11 +993,29 @@ int wan_updateDNS(WanMgr_IfaceSM_Controller_t* pWanIfaceCtrl, BOOL addIPv4, BOOL
         sysevent_set(sysevent_fd, sysevent_token, SYSEVENT_FIELD_IPV6_DNS_SECONDARY, "", 0);
     }
 
+    // update domain name
+    if (addIPv4)
+    {
+        if (p_VirtIf->IP.Ipv4Data.domain[0] != '\0')
+        {
+           snprintf(desiredDomain, sizeof(desiredDomain), "%s", p_VirtIf->IP.Ipv4Data.domain);
+           CcspTraceInfo(("%s %d: Domain received from WAN = \"%s\"\n", __FUNCTION__, __LINE__, desiredDomain));
+        }
+        else
+        {
+           CcspTraceInfo(("%s %d: Domain is not received from WAN\n", __FUNCTION__, __LINE__));
+        }
+    }
+    /* else desiredDomain stays "" - covers: IPv4 is DOWN */
+
+    CcspTraceInfo(("%s %d: Setting dhcp_domain sysevent = \"%s\"\n",  __FUNCTION__, __LINE__, desiredDomain));
+    sysevent_set(sysevent_fd, sysevent_token, SYSEVENT_IPV4_DOMAIN, desiredDomain, 0);
 
     if ( strcmp(p_VirtIf->IP.Ipv4Data.dnsServer, v4nameserver1) || strcmp(p_VirtIf->IP.Ipv4Data.dnsServer1, v4nameserver2)
+        || strcmp(desiredDomain, currentDomain)
         || strcmp(p_VirtIf->IP.Ipv6Data.nameserver, v6nameserver1) || strcmp (p_VirtIf->IP.Ipv6Data.nameserver1, v6nameserver2))
     {
-        // new and curr nameservers are differen, so apply configuration
+        // new and curr nameservers/domains are different, so apply configuration
         CcspTraceInfo(("%s %d: Setting %s\n", __FUNCTION__, __LINE__, SYSEVENT_DHCP_SERVER_RESTART));
         sysevent_set(sysevent_fd, sysevent_token, SYSEVENT_DHCP_SERVER_RESTART, NULL, 0);
     }

--- a/source/WanManager/wanmgr_sysevents.h
+++ b/source/WanManager/wanmgr_sysevents.h
@@ -55,6 +55,7 @@
 #define SYSEVENT_FIELD_IPV4_DNS_SECONDARY     "ipv4_dns_1"
 #define SYSEVENT_IPV4_GW_NUMBER "ipv4_%s_gw_number"
 #define SYSEVENT_IPV4_GW_ADDRESS "ipv4_%s_gw_0"
+#define SYSEVENT_IPV4_DOMAIN "dhcp_domain"
 #define SYSEVENT_VENDOR_CLASS "vendor_class"
 #define SYSEVENT_IPV4_DEFAULT_ROUTER "default_router"
 #define SYSEVENT_IPV4_TIME_OFFSET "ipv4-timeoffset"


### PR DESCRIPTION
Reason for change: Added provisioning to fetch the DHCPv4 Option 15 (Domain Name) value via udhcpc and forward it to the WAN Manager. The WAN Manager then sets the corresponding sysevent, enabling dnsmasq to propagate the domain name to LAN clients.

Risks: Low