### PR TITLE
RDKB-64552: DHCP Lease Expire Time IPV4 is not getting updated in GUI

### DIFF
--- a/source/WanManager/wanmgr_dhcpv4_apis.c
+++ b/source/WanManager/wanmgr_dhcpv4_apis.c
@@ -202,9 +202,11 @@ ANSC_STATUS wanmgr_handle_dhcpv4_event_data(DML_VIRTUAL_IFACE* pVirtIf)
             snprintf(value, sizeof(value), "%d", pDhcpcInfo->upstreamCurrRate);
             sysevent_set(sysevent_fd, sysevent_token, name, value, 0);
 
+#ifndef FEATURE_RDKB_DHCP_MANAGER
             snprintf(name, sizeof(name), SYSEVENT_IPV4_LEASE_TIME, pDhcpcInfo->dhcpcInterface);
             snprintf(value, sizeof(value), "%d", pDhcpcInfo->leaseTime);
             sysevent_set(sysevent_fd, sysevent_token, name, value, 0);
+#endif
 
 #if !defined(FEATURE_RDKB_CONFIGURABLE_WAN_INTERFACE)
             if (pDhcpcInfo->isTimeOffsetAssigned)

--- a/source/WanManager/wanmgr_sysevents.c
+++ b/source/WanManager/wanmgr_sysevents.c
@@ -174,6 +174,7 @@ ANSC_STATUS wanmgr_sysevents_ipv4Info_set(const ipc_dhcpv4_data_t* dhcp4Info, co
 
     sysevent_set(sysevent_fd, sysevent_token,SYSEVENT_IPV4_TIME_ZONE, dhcp4Info->timeZone, 0);
 
+#ifndef FEATURE_RDKB_DHCP_MANAGER
     snprintf(name,sizeof(name),SYSEVENT_IPV4_DHCP_SERVER,dhcp4Info->dhcpcInterface);
     sysevent_set(sysevent_fd, sysevent_token,name, dhcp4Info->dhcpServerId,0);
 
@@ -183,6 +184,7 @@ ANSC_STATUS wanmgr_sysevents_ipv4Info_set(const ipc_dhcpv4_data_t* dhcp4Info, co
     snprintf(name,sizeof(name), SYSEVENT_IPV4_LEASE_TIME, dhcp4Info->dhcpcInterface);
     snprintf(value, sizeof(value), "%u",dhcp4Info->leaseTime);
     sysevent_set(sysevent_fd, sysevent_token,name, value, 0);
+#endif
 
     return ANSC_STATUS_SUCCESS;
 }
@@ -275,7 +277,7 @@ if ( TRUE == UseWANMACForManagementServices )
     }
 
     sysevent_set(sysevent_fd, sysevent_token,SYSEVENT_IPV4_TIME_ZONE, dhcp4Info->timeZone, 0);
-
+#ifndef FEATURE_RDKB_DHCP_MANAGER
     snprintf(name,sizeof(name),SYSEVENT_IPV4_DHCP_SERVER,dhcp4Info->ifname);
     sysevent_set(sysevent_fd, sysevent_token,name, dhcp4Info->dhcpServerId,0);
 
@@ -285,7 +287,7 @@ if ( TRUE == UseWANMACForManagementServices )
     snprintf(name,sizeof(name), SYSEVENT_IPV4_LEASE_TIME, dhcp4Info->ifname);
     snprintf(value, sizeof(value), "%u",dhcp4Info->leaseTime);
     sysevent_set(sysevent_fd, sysevent_token,name, value, 0);
-
+#endif
 #endif
     return ANSC_STATUS_SUCCESS;
 }


### PR DESCRIPTION
Reason for change: DHCP Lease Expire Time IPV4 is not getting updated in GUI 
Test Procedure: Verify the ipv4 dhcp lease time in gui and dmcli cmd output 
Risks: Low
Priority: P1
Signed-off-by:Jayajothi_Gopi@comcast.com